### PR TITLE
Fix add wildcard tag bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -41,10 +42,12 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]... "
+            + "[" + PREFIX_REMOVE_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
-            + PREFIX_EMAIL + "johndoe@example.com";
+            + PREFIX_EMAIL + "johndoe@example.com "
+            + PREFIX_TAG + "CS2103";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -36,7 +36,8 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
-            + "Existing values will be overwritten by the input values.\n"
+            + "Existing non-tag values will be overwritten by the input values."
+            + "Tag values to be added can be specified with t/ and removed with rt/.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -259,7 +259,16 @@ public class EditCommand extends Command {
                     && getEmail().equals(e.getEmail())
                     && getAddress().equals(e.getAddress())
                     && getTagsToAdd().equals(e.getTagsToAdd())
-                    && getTagsToRemove().equals(e.getTagsToRemove());
+                    && (getTagsToRemove().equals(e.getTagsToRemove())
+                            || checksForWildcardTagEquality(getTagsToRemove(), e.getTagsToRemove()));
         }
+    }
+
+    /**
+     * Returns true if both tag sets contains the all_tags_tag.
+     */
+    private static boolean checksForWildcardTagEquality(Optional<Set<Tag>> tagSet1, Optional<Set<Tag>> tagSet2) {
+        return tagSet1.isPresent() && tagSet1.get().contains(Tag.ALL_TAGS_TAG)
+                && (tagSet2.isPresent() && tagSet2.get().contains(Tag.ALL_TAGS_TAG));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -57,8 +57,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTagsToAdd);
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_REMOVE_TAG)).ifPresent(editPersonDescriptor::setTagsToRemove);
+        parseTagsToEdit(argMultimap.getAllValues(PREFIX_TAG), false)
+                .ifPresent(editPersonDescriptor::setTagsToAdd);
+        parseTagsToEdit(argMultimap.getAllValues(PREFIX_TAG), true)
+                .ifPresent(editPersonDescriptor::setTagsToRemove);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
@@ -71,15 +73,16 @@ public class EditCommandParser implements Parser<EditCommand> {
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
      * If {@code tags} contain only one element which is an empty string, it will be parsed into a
      * {@code Set<Tag>} containing zero tags.
+     * If {@code canBeWildcard} is true, then the Tags produced can be the wildcard tag, i.e. ALL_TAGS_TAG.
      */
-    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
+    private Optional<Set<Tag>> parseTagsToEdit(Collection<String> tags, boolean canBeWildcard) throws ParseException {
         assert tags != null;
 
         if (tags.isEmpty()) {
             return Optional.empty();
         }
         Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseTags(tagSet));
+        return Optional.of(ParserUtil.parseTags(tagSet, canBeWildcard));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -59,7 +59,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         parseTagsToEdit(argMultimap.getAllValues(PREFIX_TAG), false)
                 .ifPresent(editPersonDescriptor::setTagsToAdd);
-        parseTagsToEdit(argMultimap.getAllValues(PREFIX_TAG), true)
+        parseTagsToEdit(argMultimap.getAllValues(PREFIX_REMOVE_TAG), true)
                 .ifPresent(editPersonDescriptor::setTagsToRemove);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -140,7 +140,7 @@ public class ParserUtil {
         return tagSet;
     }
 
-    /*
+    /**
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
      * Allows for wildcard tags if {@code canBeWildcard} is true.
      */

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -113,6 +113,22 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String tag} into a {@code Tag}.
+     * Leading and trailing whitespaces will be trimmed.
+     * Allows for wildcard tags if {@code canbeWildcard} is true.
+     *
+     * @throws ParseException if the given {@code tag} is invalid.
+     */
+    public static Tag parseTag(String tag, boolean canBeWildcard) throws ParseException {
+        requireNonNull(tag);
+        String trimmedTag = tag.trim();
+        if (!Tag.isValidTagName(trimmedTag, canBeWildcard)) {
+            throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+        }
+        return new Tag(trimmedTag, canBeWildcard);
+    }
+
+    /**
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
      */
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
@@ -120,6 +136,19 @@ public class ParserUtil {
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
             tagSet.add(parseTag(tagName));
+        }
+        return tagSet;
+    }
+
+    /*
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
+     * Allows for wildcard tags if {@code canBeWildcard} is true.
+     */
+    public static Set<Tag> parseTags(Collection<String> tags, boolean canBeWildcard) throws ParseException {
+        requireNonNull(tags);
+        final Set<Tag> tagSet = new HashSet<>();
+        for (String tagName : tags) {
+            tagSet.add(parseTag(tagName, canBeWildcard));
         }
         return tagSet;
     }
@@ -153,4 +182,5 @@ public class ParserUtil {
         }
         return new Time(trimmedTime);
     }
+
 }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -32,10 +32,30 @@ public class Tag {
     }
 
     /**
-     * Returns true if a given string is a valid tag name or an all-tags indicator.
+     * Constructs a {@code Tag}.
+     * The tag can be a wildcard {@code Tag} which represents all tags the entity has.
+     *
+     * @param tagName A valid tag name or '*'.
+     * @param canBeWildcard Indicator for whether the wildcard tag is allowed in this field.
+     */
+    public Tag(String tagName, boolean canBeWildcard) {
+        requireNonNull(tagName);
+        checkArgument(isValidTagName(tagName, canBeWildcard), MESSAGE_CONSTRAINTS);
+        this.tagName = tagName;
+    }
+
+    /**
+     * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidTagName(String test) {
-        if (test.equals(ALL_TAGS_IDENTIFIER)) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if a given string is a valid tag name or an all-tags indicator.
+     */
+    public static boolean isValidTagName(String test, boolean canBeWildcard) {
+        if (test.equals(ALL_TAGS_IDENTIFIER) && canBeWildcard) {
             return true;
         }
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -16,7 +16,7 @@ public class Tag {
     /**
      * Unique tag object to identify a tag that equates to all tags a Person has.
      */
-    public static final Tag ALL_TAGS_TAG = new Tag(ALL_TAGS_IDENTIFIER);
+    public static final Tag ALL_TAGS_TAG = new Tag(ALL_TAGS_IDENTIFIER, true);
 
     public final String tagName;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -56,7 +56,8 @@ public class CommandTestUtil {
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
-    public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby/"; // '*' not allowed in tags
+    public static final String INVALID_TAG_ADD_DESC = " " + PREFIX_TAG + "*"; // wildcard not allowed for add tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_ADD_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -40,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -101,6 +103,8 @@ public class EditCommandParserTest {
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, "1" + INVALID_TAG_ADD_DESC, Tag.MESSAGE_CONSTRAINTS);
     }
 
     @Test
@@ -217,4 +221,7 @@ public class EditCommandParserTest {
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
+
+
+
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -214,12 +214,13 @@ public class ParserUtilTest {
 
     @Test
     public void parseTagsWildcard_collectionWithWildcardTagAndFalse_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseTags(Arrays.asList(ALL_TAGS_IDENTIFIER, VALID_TAG_1)));
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseTags(Arrays.asList(ALL_TAGS_IDENTIFIER, VALID_TAG_1), false));
     }
 
     @Test
     public void parseTagsWildcard_collectionWithWildcardTagAndTrue_throwsParseException() throws ParseException {
-        Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(ALL_TAGS_IDENTIFIER, VALID_TAG_1));
+        Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(ALL_TAGS_IDENTIFIER, VALID_TAG_1), true);
         Set<Tag> expectedTagSet = Set.of(ALL_TAGS_TAG, new Tag(VALID_TAG_1));
 
         assertEquals(expectedTagSet, actualTagSet);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -3,6 +3,8 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.model.tag.Tag.ALL_TAGS_IDENTIFIER;
+import static seedu.address.model.tag.Tag.ALL_TAGS_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -172,6 +174,22 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseTagWildcard_wildcardInputWithWildcardFalse_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTag(ALL_TAGS_IDENTIFIER));
+    }
+
+    @Test
+    public void parseTagWildcard_validInputWithWildcardFalse_returnsTag() throws ParseException {
+        Tag expectedTag = new Tag(VALID_TAG_1);
+        assertEquals(expectedTag, ParserUtil.parseTag(VALID_TAG_1, false));
+    }
+
+    @Test
+    public void parseTagWildcard_wildcardInputWithWildcardTrue_returnsWildcardTag() throws ParseException {
+        assertEquals(ALL_TAGS_TAG, ParserUtil.parseTag(ALL_TAGS_IDENTIFIER, true));
+    }
+
+    @Test
     public void parseTags_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseTags(null));
     }
@@ -190,6 +208,19 @@ public class ParserUtilTest {
     public void parseTags_collectionWithValidTags_returnsTagSet() throws Exception {
         Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, VALID_TAG_2));
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
+
+        assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseTagsWildcard_collectionWithWildcardTagAndFalse_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTags(Arrays.asList(ALL_TAGS_IDENTIFIER, VALID_TAG_1)));
+    }
+
+    @Test
+    public void parseTagsWildcard_collectionWithWildcardTagAndTrue_throwsParseException() throws ParseException {
+        Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(ALL_TAGS_IDENTIFIER, VALID_TAG_1));
+        Set<Tag> expectedTagSet = Set.of(ALL_TAGS_TAG, new Tag(VALID_TAG_1));
 
         assertEquals(expectedTagSet, actualTagSet);
     }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -91,7 +91,7 @@ public class EditPersonDescriptorBuilder {
      * that we are building.
      */
     public EditPersonDescriptorBuilder withTagsToRemove(String... tags) {
-        Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
+        Set<Tag> tagSet = Stream.of(tags).map(tag -> new Tag(tag, true)).collect(Collectors.toSet());
         descriptor.setTagsToRemove(tagSet);
         return this;
     }


### PR DESCRIPTION
The `Tag` class was updated with additional methods and constructor that accept a boolean flag to determine if wildcard tags should be enabled. `Tag` default constructor and validity checking methods have been reverted to their original form for ease of use by others.