### PR TITLE
Create tag manager

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -8,6 +8,8 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.tag.TagManager;
+import seedu.address.model.tag.TagManagerImpl;
 
 /**
  * Wraps all data at the address-book level
@@ -16,6 +18,7 @@ import seedu.address.model.person.UniquePersonList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
+    private final TagManager tagManager;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -26,6 +29,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniquePersonList();
+        tagManager = new TagManagerImpl();
     }
 
     public AddressBook() {}
@@ -48,6 +52,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         this.persons.setPersons(persons);
     }
 
+    public void setTagManager(List<Person> persons) {
+        this.tagManager.addNewPersonsTags(persons);
+    }
+
     /**
      * Resets the existing data of this {@code AddressBook} with {@code newData}.
      */
@@ -55,6 +63,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(newData);
 
         setPersons(newData.getPersonList());
+        setTagManager(newData.getPersonList());
     }
 
     //// person-level operations
@@ -73,6 +82,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void addPerson(Person p) {
         persons.add(p);
+        tagManager.addNewPersonTags(p);
     }
 
     /**
@@ -84,6 +94,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(editedPerson);
 
         persons.setPerson(target, editedPerson);
+        tagManager.updateExistingPersonTags(target, editedPerson);
     }
 
     /**
@@ -92,6 +103,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+        tagManager.deletePersonTags(key);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -4,10 +4,12 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.TagManager;
 import seedu.address.model.tag.TagManagerImpl;
 
@@ -110,6 +112,10 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     public void sortPerson(Comparator<Person> c) {
         persons.sortPersons(c);
+    }
+
+    public Set<Person> getPersonsWithTag(Tag tag) {
+        return tagManager.getPersonsUnderTag(tag);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -122,13 +122,19 @@ public interface Model {
      */
     void setEvent(Event target, Event editedEvent);
 
-    /** Returns an unmodifiable view of the filtered person list */
+    /**
+     * Returns an unmodifiable view of the filtered person list
+     */
     ObservableList<Person> getSortedFilteredPersonList();
 
-    /** Returns an unmodifiable view of the filtered event list */
+    /**
+     * Returns an unmodifiable view of the filtered event list
+     */
     ObservableList<Event> getFilteredEventList();
 
-    /** Returns a set of all {@code person}s containing the {@code tag}. */
+    /**
+     * Returns a set of all {@code person}s containing the {@code tag}.
+     */
     Set<Person> getPersonsWithTag(Tag tag);
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -2,12 +2,14 @@ package seedu.address.model;
 
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.event.Event;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 
 /**
  * The API of the Model component.
@@ -125,6 +127,9 @@ public interface Model {
 
     /** Returns an unmodifiable view of the filtered event list */
     ObservableList<Event> getFilteredEventList();
+
+    /** Returns a set of all {@code person}s containing the {@code tag}. */
+    Set<Person> getPersonsWithTag(Tag tag);
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -15,6 +16,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.event.Event;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -187,6 +189,11 @@ public class ModelManager implements Model {
     @Override
     public ObservableList<Event> getFilteredEventList() {
         return filteredEvents;
+    }
+
+    @Override
+    public Set<Person> getPersonsWithTag(Tag tag) {
+        return addressBook.getPersonsWithTag(tag);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/TagManager.java
+++ b/src/main/java/seedu/address/model/tag/TagManager.java
@@ -1,5 +1,6 @@
 package seedu.address.model.tag;
 
+import java.util.Collection;
 import java.util.Set;
 
 import seedu.address.model.person.Person;
@@ -29,17 +30,35 @@ public interface TagManager {
      * Updates the current tag references in the tag manager.
      * Removes all references to the {@code oldPerson} and adds new references to the {@code newPerson}.
      *
-     * @param oldPerson {@code Person} that we would like to remove references to.
-     * @param newPerson {@code Person} that we would like to add new references to.
+     * @param oldPerson {@code Person} to remove references to.
+     * @param newPerson {@code Person} to add new references to.
      */
     void updateExistingPersonTags(Person oldPerson, Person newPerson);
 
     /**
      * Updates the tag manager with references to a newly added {@code person}.
      *
-     * @param person new {@person} added.
+     * @param person new {@code person} added.
      */
-    void updateNewPersonTags(Person person);
+    void addNewPersonTags(Person person);
+
+    /**
+     * Updates the tag manager with references to all {@code person} in {@code persons}.
+     *
+     * @param persons new {@code persons} added.
+     */
+    default void addNewPersonsTags(Collection<Person> persons) {
+        for (Person person : persons) {
+            addNewPersonTags(person);
+        }
+    }
+
+    /**
+     * Updates the current {@code tag} references in the {@code tag manager} to remove all references to {@code person}.
+     *
+     * @param person person being deleted.
+     */
+    void deletePersonTags(Person person);
 
     /**
      * Copies the content of the {@code otherTagManager} into this {@code TagManager}.

--- a/src/main/java/seedu/address/model/tag/TagManager.java
+++ b/src/main/java/seedu/address/model/tag/TagManager.java
@@ -34,5 +34,14 @@ public interface TagManager {
      */
     void updateNewPersonTags(Person person);
 
+    /**
+     * Creates and returns a copy of the {@code TagManager}.
+     * The new copy must use a separate underlying structure, only sharing references
+     * to the same {@code Person}s and {@code Tag}s.
+     *
+     * @return copy of the current {@code TagManager}.
+     */
+    TagManager copy();
+
 
 }

--- a/src/main/java/seedu/address/model/tag/TagManager.java
+++ b/src/main/java/seedu/address/model/tag/TagManager.java
@@ -19,6 +19,13 @@ public interface TagManager {
     Set<Person> getPersonsUnderTag(Tag tag);
 
     /**
+     * Returns a set of all {@code Tag}s found in the {@code TagManager}.
+     *
+     * @return a set of {@code Tag}s.
+     */
+    Set<Tag> getTags();
+
+    /**
      * Updates the current tag references in the tag manager.
      * Removes all references to the {@code oldPerson} and adds new references to the {@code newPerson}.
      *
@@ -35,13 +42,11 @@ public interface TagManager {
     void updateNewPersonTags(Person person);
 
     /**
-     * Creates and returns a copy of the {@code TagManager}.
+     * Copies the content of the {@code otherTagManager} into this {@code TagManager}.
      * The new copy must use a separate underlying structure, only sharing references
      * to the same {@code Person}s and {@code Tag}s.
-     *
-     * @return copy of the current {@code TagManager}.
      */
-    TagManager copy();
+    void copy(TagManager otherTagManager);
 
 
 }

--- a/src/main/java/seedu/address/model/tag/TagManager.java
+++ b/src/main/java/seedu/address/model/tag/TagManager.java
@@ -1,0 +1,38 @@
+package seedu.address.model.tag;
+
+import java.util.Set;
+
+import seedu.address.model.person.Person;
+
+/**
+ * Interface dictating the behavior of a {@code TagManager} class that keeps track of {@code Person}s
+ * under each {@code Tag}.
+ */
+public interface TagManager {
+
+    /**
+     * Returns a set of all {@code Person}s that has this tag.
+     *
+     * @param tag common {@code tag} that all persons we are looking for has.
+     * @return set of {@code Person}s that has {@tag}.
+     */
+    Set<Person> getPersonsUnderTag(Tag tag);
+
+    /**
+     * Updates the current tag references in the tag manager.
+     * Removes all references to the {@code oldPerson} and adds new references to the {@code newPerson}.
+     *
+     * @param oldPerson {@code Person} that we would like to remove references to.
+     * @param newPerson {@code Person} that we would like to add new references to.
+     */
+    void updateExistingPersonTags(Person oldPerson, Person newPerson);
+
+    /**
+     * Updates the tag manager with references to a newly added {@code person}.
+     *
+     * @param person new {@person} added.
+     */
+    void updateNewPersonTags(Person person);
+
+
+}

--- a/src/main/java/seedu/address/model/tag/TagManagerImpl.java
+++ b/src/main/java/seedu/address/model/tag/TagManagerImpl.java
@@ -34,29 +34,25 @@ public class TagManagerImpl implements TagManager {
         return tagPersonSetMap.keySet();
     }
 
-    @Override
-    public void updateExistingPersonTags(Person oldPerson, Person newPerson) {
-        for (Tag oldTag : oldPerson.getTags()) {
+    /**
+     * Removes all references in {@code tagPersonSetMap} to this {@code person} based on the {@code tag}s it has.
+     */
+    private void removeAllTagReferencesOfPerson(Person person) {
+        for (Tag oldTag : person.getTags()) {
             Set<Person> tagSet = tagPersonSetMap.get(oldTag);
             Objects.requireNonNull(tagSet);
-            if (!tagSet.contains(oldPerson)) {
+            if (!tagSet.contains(person)) {
                 throw new NoSuchElementException(MESSAGE_ERROR_PERSON_NOT_FOUND);
             }
 
-            tagSet.remove(oldPerson);
-        }
-
-        for (Tag newTag : newPerson.getTags()) {
-            Optional.ofNullable(tagPersonSetMap.get(newTag))
-                    .ifPresentOrElse(
-                            set -> set.add(newPerson),
-                            () -> tagPersonSetMap.put(newTag, new HashSet<>(List.of(newPerson)))
-                    );
+            tagSet.remove(person);
         }
     }
 
-    @Override
-    public void updateNewPersonTags(Person person) {
+    /**
+     * Adds all references to {@code tagPersonSetMap} from this {@code person} based on the {@code tag}s it has.
+     */
+    private void addAllTagReferencesOfPerson(Person person) {
         for (Tag newTag : person.getTags()) {
             Optional.ofNullable(tagPersonSetMap.get(newTag))
                     .ifPresentOrElse(
@@ -64,6 +60,22 @@ public class TagManagerImpl implements TagManager {
                             () -> tagPersonSetMap.put(newTag, new HashSet<>(List.of(person)))
                     );
         }
+    }
+
+    @Override
+    public void updateExistingPersonTags(Person oldPerson, Person newPerson) {
+        removeAllTagReferencesOfPerson(oldPerson);
+        addAllTagReferencesOfPerson(newPerson);
+    }
+
+    @Override
+    public void addNewPersonTags(Person person) {
+        addAllTagReferencesOfPerson(person);
+    }
+
+    @Override
+    public void deletePersonTags(Person person) {
+        removeAllTagReferencesOfPerson(person);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/TagManagerImpl.java
+++ b/src/main/java/seedu/address/model/tag/TagManagerImpl.java
@@ -24,10 +24,16 @@ public class TagManagerImpl implements TagManager {
         tagPersonSetMap = new HashMap<>();
     }
 
+    private TagManagerImpl(Map<Tag, Set<Person>> mapCopy) {
+        this.tagPersonSetMap = mapCopy;
+    }
+
+    @Override
     public Set<Person> getPersonsUnderTag(Tag tag) {
         return tagPersonSetMap.get(tag);
     }
 
+    @Override
     public void updateExistingPersonTags(Person oldPerson, Person newPerson) {
         for (Tag oldTag : oldPerson.getTags()) {
             Set<Person> tagSet = tagPersonSetMap.get(oldTag);
@@ -48,6 +54,7 @@ public class TagManagerImpl implements TagManager {
         }
     }
 
+    @Override
     public void updateNewPersonTags(Person person) {
         for (Tag newTag : person.getTags()) {
             Optional.ofNullable(tagPersonSetMap.get(newTag))
@@ -58,6 +65,14 @@ public class TagManagerImpl implements TagManager {
         }
     }
 
+    @Override
+    public TagManagerImpl copy() {
+        HashMap<Tag, Set<Person>> newMap = new HashMap<>();
+        for (Map.Entry<Tag, Set<Person>> mapEntry : tagPersonSetMap.entrySet()) {
+            newMap.put(mapEntry.getKey(), new HashSet<>(mapEntry.getValue()));
+        }
+        return new TagManagerImpl(newMap);
+    }
 
 
 }

--- a/src/main/java/seedu/address/model/tag/TagManagerImpl.java
+++ b/src/main/java/seedu/address/model/tag/TagManagerImpl.java
@@ -26,7 +26,7 @@ public class TagManagerImpl implements TagManager {
 
     @Override
     public Set<Person> getPersonsUnderTag(Tag tag) {
-        return tagPersonSetMap.get(tag);
+        return tagPersonSetMap.get(tag) == null ? Set.of() : tagPersonSetMap.get(tag);
     }
 
     @Override
@@ -46,6 +46,9 @@ public class TagManagerImpl implements TagManager {
             }
 
             tagSet.remove(person);
+            if (tagSet.size() == 0) {
+                tagPersonSetMap.remove(oldTag);
+            }
         }
     }
 
@@ -87,5 +90,15 @@ public class TagManagerImpl implements TagManager {
         tagPersonSetMap.putAll(newMap);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        } else if (!(o instanceof TagManagerImpl)) {
+            return false;
+        } else {
+            return tagPersonSetMap.equals(((TagManagerImpl) o).tagPersonSetMap);
+        }
+    }
 
 }

--- a/src/main/java/seedu/address/model/tag/TagManagerImpl.java
+++ b/src/main/java/seedu/address/model/tag/TagManagerImpl.java
@@ -24,13 +24,14 @@ public class TagManagerImpl implements TagManager {
         tagPersonSetMap = new HashMap<>();
     }
 
-    private TagManagerImpl(Map<Tag, Set<Person>> mapCopy) {
-        this.tagPersonSetMap = mapCopy;
-    }
-
     @Override
     public Set<Person> getPersonsUnderTag(Tag tag) {
         return tagPersonSetMap.get(tag);
+    }
+
+    @Override
+    public Set<Tag> getTags() {
+        return tagPersonSetMap.keySet();
     }
 
     @Override
@@ -66,12 +67,12 @@ public class TagManagerImpl implements TagManager {
     }
 
     @Override
-    public TagManagerImpl copy() {
+    public void copy(TagManager otherTagManager) {
         HashMap<Tag, Set<Person>> newMap = new HashMap<>();
-        for (Map.Entry<Tag, Set<Person>> mapEntry : tagPersonSetMap.entrySet()) {
-            newMap.put(mapEntry.getKey(), new HashSet<>(mapEntry.getValue()));
+        for (Tag tag : otherTagManager.getTags()) {
+            newMap.put(tag, new HashSet<>(otherTagManager.getPersonsUnderTag(tag)));
         }
-        return new TagManagerImpl(newMap);
+        tagPersonSetMap.putAll(newMap);
     }
 
 

--- a/src/main/java/seedu/address/model/tag/TagManagerImpl.java
+++ b/src/main/java/seedu/address/model/tag/TagManagerImpl.java
@@ -1,7 +1,5 @@
 package seedu.address.model.tag;
 
-import seedu.address.model.person.Person;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -10,6 +8,8 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+
+import seedu.address.model.person.Person;
 
 /**
  * Concrete implementation class of {@code TagManager} that uses a {@code HashMap}.
@@ -59,9 +59,7 @@ public class TagManagerImpl implements TagManager {
         for (Tag newTag : person.getTags()) {
             Optional.ofNullable(tagPersonSetMap.get(newTag))
                     .ifPresentOrElse(
-                            set -> set.add(person),
-                            () -> tagPersonSetMap.put(newTag, new HashSet<>(List.of(person)))
-                    );
+                        set -> set.add(person), () -> tagPersonSetMap.put(newTag, new HashSet<>(List.of(person))));
         }
     }
 

--- a/src/main/java/seedu/address/model/tag/TagManagerImpl.java
+++ b/src/main/java/seedu/address/model/tag/TagManagerImpl.java
@@ -1,0 +1,63 @@
+package seedu.address.model.tag;
+
+import seedu.address.model.person.Person;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Concrete implementation class of {@code TagManager} that uses a {@code HashMap}.
+ */
+public class TagManagerImpl implements TagManager {
+
+    private static final String MESSAGE_ERROR_PERSON_NOT_FOUND = "Person instance not found in tag manager!";
+
+    private final Map<Tag, Set<Person>> tagPersonSetMap;
+
+    public TagManagerImpl() {
+        tagPersonSetMap = new HashMap<>();
+    }
+
+    public Set<Person> getPersonsUnderTag(Tag tag) {
+        return tagPersonSetMap.get(tag);
+    }
+
+    public void updateExistingPersonTags(Person oldPerson, Person newPerson) {
+        for (Tag oldTag : oldPerson.getTags()) {
+            Set<Person> tagSet = tagPersonSetMap.get(oldTag);
+            Objects.requireNonNull(tagSet);
+            if (!tagSet.contains(oldPerson)) {
+                throw new NoSuchElementException(MESSAGE_ERROR_PERSON_NOT_FOUND);
+            }
+
+            tagSet.remove(oldPerson);
+        }
+
+        for (Tag newTag : newPerson.getTags()) {
+            Optional.ofNullable(tagPersonSetMap.get(newTag))
+                    .ifPresentOrElse(
+                            set -> set.add(newPerson),
+                            () -> tagPersonSetMap.put(newTag, new HashSet<>(List.of(newPerson)))
+                    );
+        }
+    }
+
+    public void updateNewPersonTags(Person person) {
+        for (Tag newTag : person.getTags()) {
+            Optional.ofNullable(tagPersonSetMap.get(newTag))
+                    .ifPresentOrElse(
+                            set -> set.add(person),
+                            () -> tagPersonSetMap.put(newTag, new HashSet<>(List.of(person)))
+                    );
+        }
+    }
+
+
+
+}

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import seedu.address.model.ReadOnlyCalendar;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.event.Event;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -193,6 +195,11 @@ public class AddCommandTest {
 
         @Override
         public ObservableList<Event> getFilteredEventList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Set<Person> getPersonsWithTag(Tag tag) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/model/AddressBookTagManagerIntegrationTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTagManagerIntegrationTest.java
@@ -11,6 +11,9 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests integration between AddressBook and the TagManager.
+ */
 public class AddressBookTagManagerIntegrationTest {
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTagManagerIntegrationTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTagManagerIntegrationTest.java
@@ -1,0 +1,43 @@
+package seedu.address.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.model.tag.TagManagerImplTest.BENSON_EDITED;
+import static seedu.address.model.tag.TagManagerImplTest.TAG_FRIENDS;
+import static seedu.address.model.tag.TagManagerImplTest.TAG_MODULE;
+import static seedu.address.model.tag.TagManagerImplTest.TAG_OWES_MONEY;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+
+public class AddressBookTagManagerIntegrationTest {
+
+    private static final AddressBook addressBook = new AddressBook();
+
+    @Test
+    public void getPersonsWithTag_newPerson_success() {
+        addressBook.addPerson(ALICE);
+        assertTrue(addressBook.getPersonsWithTag(TAG_FRIENDS).contains(ALICE));
+    }
+
+    @Test
+    public void getPersonWithTag_editPerson_success() {
+        addressBook.addPerson(BENSON);
+        addressBook.setPerson(BENSON, BENSON_EDITED);
+
+        assertTrue(addressBook.getPersonsWithTag(TAG_OWES_MONEY).isEmpty());
+        assertTrue(addressBook.getPersonsWithTag(TAG_MODULE).contains(BENSON_EDITED));
+
+        // Checks that the Person object under the friends tag is the new edited Person object instead of the old.
+        assertFalse(addressBook.getPersonsWithTag(TAG_FRIENDS).contains(BENSON));
+        assertTrue(addressBook.getPersonsWithTag(TAG_FRIENDS).contains(BENSON_EDITED));
+    }
+
+    @Test
+    public void getPersonWithTag_deletePerson_success() {
+        addressBook.addPerson(ALICE);
+        addressBook.removePerson(ALICE);
+        assertFalse(addressBook.getPersonsWithTag(TAG_FRIENDS).contains(ALICE));
+    }
+}

--- a/src/test/java/seedu/address/model/AddressBookTagManagerIntegrationTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTagManagerIntegrationTest.java
@@ -1,7 +1,5 @@
 package seedu.address.model;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.tag.TagManagerImplTest.BENSON_EDITED;
@@ -11,18 +9,20 @@ import static seedu.address.model.tag.TagManagerImplTest.TAG_OWES_MONEY;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
-public class AddressBookTagManagerIntegrationTest {
+import org.junit.jupiter.api.Test;
 
-    private static final AddressBook addressBook = new AddressBook();
+public class AddressBookTagManagerIntegrationTest {
 
     @Test
     public void getPersonsWithTag_newPerson_success() {
+        AddressBook addressBook = new AddressBook();
         addressBook.addPerson(ALICE);
         assertTrue(addressBook.getPersonsWithTag(TAG_FRIENDS).contains(ALICE));
     }
 
     @Test
     public void getPersonWithTag_editPerson_success() {
+        AddressBook addressBook = new AddressBook();
         addressBook.addPerson(BENSON);
         addressBook.setPerson(BENSON, BENSON_EDITED);
 
@@ -36,6 +36,7 @@ public class AddressBookTagManagerIntegrationTest {
 
     @Test
     public void getPersonWithTag_deletePerson_success() {
+        AddressBook addressBook = new AddressBook();
         addressBook.addPerson(ALICE);
         addressBook.removePerson(ALICE);
         assertFalse(addressBook.getPersonsWithTag(TAG_FRIENDS).contains(ALICE));

--- a/src/test/java/seedu/address/model/tag/TagManagerImplTest.java
+++ b/src/test/java/seedu/address/model/tag/TagManagerImplTest.java
@@ -29,7 +29,9 @@ public class TagManagerImplTest {
         return new TagManagerImpl();
     }
 
-    /** Contains the tags "friends" (ALICE & BENSON) and "owesMoney" (BENSON) */
+    /**
+     * Contains the tags "friends" (ALICE & BENSON) and "owesMoney" (BENSON)
+     */
     public static TagManagerImpl createNonEmptyTagManager() {
         TagManagerImpl tagManager = new TagManagerImpl();
         tagManager.addNewPersonTags(ALICE);

--- a/src/test/java/seedu/address/model/tag/TagManagerImplTest.java
+++ b/src/test/java/seedu/address/model/tag/TagManagerImplTest.java
@@ -1,0 +1,108 @@
+package seedu.address.model.tag;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
+
+public class TagManagerImplTest {
+
+    private static final Tag TAG_FRIENDS = new Tag("friends");
+    private static final Tag TAG_OWES_MONEY = new Tag("owesMoney");
+    private static final Tag TAG_MODULE = new Tag("CS2103");
+    private static final Tag TAG_NOT_FOUND = new Tag("asdimsad");
+    private static final Tag TAG_SCHOOL = new Tag("NUS");
+    private static final Person BENSON_EDITED = new PersonBuilder(BENSON).withTags("friends", "CS2103", "NUS").build();
+
+    private static TagManagerImpl createEmptyTagManager() {
+        return new TagManagerImpl();
+    }
+
+    /** Contains the tags "friends" (ALICE & BENSON) and "owesMoney" (BENSON) */
+    private static TagManagerImpl createNonEmptyTagManager() {
+        TagManagerImpl tagManager = new TagManagerImpl();
+        tagManager.addNewPersonTags(ALICE);
+        tagManager.addNewPersonTags(BENSON);
+        return tagManager;
+    }
+
+    @Test
+    public void getTags_nonExistentTag_emptyCollectionReturn() {
+        assertTrue(createNonEmptyTagManager().getPersonsUnderTag(TAG_NOT_FOUND).isEmpty());
+    }
+
+    @Test
+    public void getTags_existingTag_correctCollectionReturn() {
+        Set<Person> personSet = createNonEmptyTagManager().getPersonsUnderTag(TAG_FRIENDS);
+        assertTrue(personSet.contains(ALICE));
+        assertTrue(personSet.contains(BENSON));
+
+        personSet = createNonEmptyTagManager().getPersonsUnderTag(TAG_OWES_MONEY);
+        assertTrue(personSet.contains(BENSON));
+        assertFalse(personSet.contains(ALICE));
+
+    }
+
+    @Test
+    public void addNewPerson_newTags_success() {
+        // This relies on the fact that GEORGE's tag CS2103 is not inside the non-empty tag manager.
+        TagManagerImpl tagManager = createEmptyTagManager();
+        tagManager.addNewPersonTags(GEORGE);
+        assertTrue(tagManager.getPersonsUnderTag(TAG_MODULE).contains(GEORGE));
+
+        tagManager = createNonEmptyTagManager();
+        tagManager.addNewPersonTags(GEORGE);
+        assertTrue(tagManager.getPersonsUnderTag(TAG_MODULE).contains(GEORGE));
+    }
+
+    @Test
+    public void deletePerson_validPersonWithTags_success() {
+        TagManagerImpl tagManager = createNonEmptyTagManager();
+        tagManager.deletePersonTags(BENSON);
+        assertFalse(tagManager.getPersonsUnderTag(TAG_FRIENDS).contains(BENSON));
+        assertTrue(tagManager.getPersonsUnderTag(TAG_OWES_MONEY).isEmpty());
+    }
+
+    @Test
+    public void editPerson_personWithChangedTags_success() {
+        TagManagerImpl tagManager = createNonEmptyTagManager();
+        tagManager.updateExistingPersonTags(BENSON, BENSON_EDITED);
+
+        assertTrue(tagManager.getPersonsUnderTag(TAG_OWES_MONEY).isEmpty());
+        assertTrue(tagManager.getPersonsUnderTag(TAG_MODULE).contains(BENSON_EDITED));
+
+        // Checks that the Person object under the friends tag is the new edited Person object instead of the old.
+        assertFalse(tagManager.getPersonsUnderTag(TAG_FRIENDS).contains(BENSON));
+        assertTrue(tagManager.getPersonsUnderTag(TAG_FRIENDS).contains(BENSON_EDITED));
+    }
+
+    @Test
+    public void allMethods_personWithNoTags_noChange() {
+        Person personNoTags = new PersonBuilder(FIONA).withTags().build();
+        Person personNoTagsNewAddress = new PersonBuilder(personNoTags).withAddress("some place").build();
+        TagManagerImpl tagManager = createNonEmptyTagManager();
+
+        // add makes no change
+        tagManager.addNewPersonTags(personNoTags);
+        assertEquals(tagManager, createNonEmptyTagManager());
+
+        // edit makes no change
+        tagManager.updateExistingPersonTags(personNoTags, personNoTagsNewAddress);
+        assertEquals(tagManager, createNonEmptyTagManager());
+
+        // delete makes no change
+        tagManager.deletePersonTags(personNoTagsNewAddress);
+        assertEquals(tagManager, createNonEmptyTagManager());
+    }
+
+
+}

--- a/src/test/java/seedu/address/model/tag/TagManagerImplTest.java
+++ b/src/test/java/seedu/address/model/tag/TagManagerImplTest.java
@@ -1,11 +1,5 @@
 package seedu.address.model.tag;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.model.person.Person;
-import seedu.address.testutil.PersonBuilder;
-
-import java.util.Set;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -13,6 +7,14 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.GEORGE;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
 
 public class TagManagerImplTest {
 

--- a/src/test/java/seedu/address/model/tag/TagManagerImplTest.java
+++ b/src/test/java/seedu/address/model/tag/TagManagerImplTest.java
@@ -16,19 +16,19 @@ import static seedu.address.testutil.TypicalPersons.GEORGE;
 
 public class TagManagerImplTest {
 
-    private static final Tag TAG_FRIENDS = new Tag("friends");
-    private static final Tag TAG_OWES_MONEY = new Tag("owesMoney");
-    private static final Tag TAG_MODULE = new Tag("CS2103");
-    private static final Tag TAG_NOT_FOUND = new Tag("asdimsad");
-    private static final Tag TAG_SCHOOL = new Tag("NUS");
-    private static final Person BENSON_EDITED = new PersonBuilder(BENSON).withTags("friends", "CS2103", "NUS").build();
+    public static final Tag TAG_FRIENDS = new Tag("friends");
+    public static final Tag TAG_OWES_MONEY = new Tag("owesMoney");
+    public static final Tag TAG_MODULE = new Tag("CS2103");
+    public static final Tag TAG_NOT_FOUND = new Tag("asdimsad");
+    public static final Tag TAG_SCHOOL = new Tag("NUS");
+    public static final Person BENSON_EDITED = new PersonBuilder(BENSON).withTags("friends", "CS2103", "NUS").build();
 
-    private static TagManagerImpl createEmptyTagManager() {
+    public static TagManagerImpl createEmptyTagManager() {
         return new TagManagerImpl();
     }
 
     /** Contains the tags "friends" (ALICE & BENSON) and "owesMoney" (BENSON) */
-    private static TagManagerImpl createNonEmptyTagManager() {
+    public static TagManagerImpl createNonEmptyTagManager() {
         TagManagerImpl tagManager = new TagManagerImpl();
         tagManager.addNewPersonTags(ALICE);
         tagManager.addNewPersonTags(BENSON);


### PR DESCRIPTION
To perform the new query for all `Person` under a certain `Tag`, simply perform `model.getPersonsWithTag(Tag)` which returns a `Set` of `Person`s or an empty `Set` if `Tag` is not present.

The choice of implementation to tag the `TagManager` to `AddressBook` was to ensure backward compatibility without having to change any large amounts of code in order to keep track of the tagging.

The current implementation takes advantage of the fact that all permanent changes to the list of `Person`s is done only through `AddressBook` methods. As such, it would make sense for the tracking to be as close to the change as possible.

However, this also creates new dependencies between `Model` and `AddressBook` to `Tag` that were not present previously. I do believe this is necessary as we are adding more features that use `Tag`s. There might be a necessity to elevate the `Tag` class to a similar level of importance as `Person` and `Event`.