### PR TITLE
Update ClearCommand and relevant classes to ClearContactCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearContactCommand.java
@@ -8,9 +8,11 @@ import seedu.address.model.Model;
 /**
  * Clears the address book.
  */
-public class ClearCommand extends Command {
+public class ClearContactCommand extends Command {
 
     public static final String COMMAND_WORD = CommandWord.CLEAR.toString();
+
+    public static final String COMMAND_TYPE = CommandType.CONTACT.toString();
 
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,7 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearContactCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandType;
 import seedu.address.logic.commands.CommandWord;
@@ -57,6 +57,9 @@ public class AddressBookParser {
             case EDIT:
                 return new EditContactCommandParser().parse(arguments);
 
+            case CLEAR:
+                return new ClearContactCommand();
+
             case DELETE:
                 return new DeleteCommandParser().parse(arguments);
 
@@ -102,9 +105,6 @@ public class AddressBookParser {
         default:
 
             switch (commandWord) {
-
-            case CLEAR:
-                return new ClearCommand();
 
             case EXIT:
                 return new ExitCommand();

--- a/src/test/java/seedu/address/logic/commands/ClearContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearContactCommandTest.java
@@ -10,14 +10,14 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
-public class ClearCommandTest {
+public class ClearContactCommandTest {
 
     @Test
     public void execute_emptyAddressBook_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearContactCommand(), model, ClearContactCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -26,7 +26,7 @@ public class ClearCommandTest {
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel.setAddressBook(new AddressBook());
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearContactCommand(), model, ClearContactCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
@@ -164,7 +164,7 @@ public class EditContactCommandTest {
         assertFalse(standardCommand.equals(null));
 
         // different types -> returns false
-        assertFalse(standardCommand.equals(new ClearCommand()));
+        assertFalse(standardCommand.equals(new ClearContactCommand()));
 
         // different index -> returns false
         assertFalse(standardCommand.equals(new EditContactCommand(INDEX_SECOND_PERSON, DESC_AMY)));

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -45,8 +45,11 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearContactCommand.COMMAND_WORD) instanceof ClearContactCommand);
-        assertTrue(parser.parseCommand(ClearContactCommand.COMMAND_WORD + " 3") instanceof ClearContactCommand);
+        assertTrue(parser.parseCommand(ClearContactCommand.COMMAND_WORD + " " + ClearContactCommand.COMMAND_TYPE)
+                instanceof ClearContactCommand);
+        assertTrue(parser.parseCommand(
+                ClearContactCommand.COMMAND_WORD + " " + ClearContactCommand.COMMAND_TYPE + " 3")
+                instanceof ClearContactCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddContactCommand;
-import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearContactCommand;
 import seedu.address.logic.commands.DeleteContactCommand;
 import seedu.address.logic.commands.EditContactCommand;
 import seedu.address.logic.commands.EditContactCommand.EditPersonDescriptor;
@@ -45,8 +45,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearContactCommand.COMMAND_WORD) instanceof ClearContactCommand);
+        assertTrue(parser.parseCommand(ClearContactCommand.COMMAND_WORD + " 3") instanceof ClearContactCommand);
     }
 
     @Test


### PR DESCRIPTION
Resolves #121 partially. `clear` for events is now linked to #126 instead.