### PR TITLE
Create edit tag command

### DIFF
--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -51,4 +51,9 @@ public class Index {
                 || (other instanceof Index // instanceof handles nulls
                 && zeroBasedIndex == ((Index) other).zeroBasedIndex); // state check
     }
+
+    @Override
+    public int hashCode() {
+        return zeroBasedIndex;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
@@ -46,6 +46,8 @@ public class EditTagCommand extends Command {
             + "Do not assign a super-tag as a sub-tag to the tag you are editing.";
     public static final String MESSAGE_NOT_EDITED =
             "None of the edit fields have been properly specified! Please specify at least one";
+    public static final String MESSAGE_TAG_TO_EDIT_NOT_PRESENT =
+            "%s does not exist in Athena!";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + COMMAND_TYPE
             + ": Edits an existing tag in Athena. You can add and/or remove contacts from a tag, and/or "
@@ -115,6 +117,11 @@ public class EditTagCommand extends Command {
     private void checkInputValidity(Model model) throws CommandException {
         boolean hasPersonToRemoveWithoutTag = getPersonsAtIndices(model, indexSetToRemove).stream()
                 .anyMatch(person -> !person.getTags().contains(tagToEdit));
+
+        if (!model.hasTag(tagToEdit)) {
+            throw new CommandException(String.format(MESSAGE_TAG_TO_EDIT_NOT_PRESENT, tagToEdit));
+        }
+
         if (hasPersonToRemoveWithoutTag) {
             throw new CommandException(String.format(MESSAGE_REMOVE_CONTACT_DOES_NOT_HAVE_TAG, tagToEdit));
         }

--- a/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
@@ -1,6 +1,5 @@
-package seedu.address.logic.parser.tags;
+package seedu.address.logic.commands.tags;
 
-import com.sun.scenario.effect.Blend;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;

--- a/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
@@ -26,17 +26,17 @@ public class EditTagCommand extends Command {
     public static final String COMMAND_WORD = CommandWord.EDIT.toString();
     public static final String COMMAND_TYPE = CommandType.TAG.toString();
 
-    private static final String MESSAGE_REMOVE_CONTACT_DOES_NOT_HAVE_TAG =
+    public static final String MESSAGE_REMOVE_CONTACT_DOES_NOT_HAVE_TAG =
             "One of the specified indices to remove does not have %s as a tag";
-    private static final String MESSAGE_ADD_CONTACT_HAS_TAG =
+    public static final String MESSAGE_ADD_CONTACT_HAS_TAG =
             "One of the specified indices to add already has %s as a tag";
-    private static final String MESSAGE_REMOVE_TAG_NOT_PRESENT =
+    public static final String MESSAGE_REMOVE_TAG_NOT_PRESENT =
             "One of the specified tags to remove is already not a child-tag of %s";
-    private static final String MESSAGE_ADD_TAG_PRESENT =
+    public static final String MESSAGE_ADD_TAG_PRESENT =
             "One of the specified tags to add is already a child-tag of %s";
-    private static final String MESSAGE_SUCCESS =
+    public static final String MESSAGE_SUCCESS =
             "%s has successfully been edited!";
-    private static final String MESSAGE_CYCLIC_DEPENDENCY_DETECTED =
+    public static final String MESSAGE_CYCLIC_DEPENDENCY_DETECTED =
             "Cyclic dependency detected between %s and %s! "
             + "Do not assign a super-tag as a sub-tag to the tag you are editing.";
 

--- a/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_INDEX;
@@ -59,6 +60,8 @@ public class EditTagCommand extends Command {
 
     public EditTagCommand(Tag tagToEdit, Set<Index> indexSetToAdd, Set<Index> indexSetToRemove,
             Set<Tag> tagSetToAdd, Set<Tag> tagSetToRemove) {
+        requireAllNonNull(tagToEdit, indexSetToAdd, indexSetToRemove, tagSetToAdd, tagSetToRemove);
+
         this.tagToEdit = tagToEdit;
         this.indexSetToAdd = indexSetToAdd;
         this.indexSetToRemove = indexSetToRemove;

--- a/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
@@ -36,6 +36,9 @@ public class EditTagCommand extends Command {
             "One of the specified tags to add is already a child-tag of %s";
     private static final String MESSAGE_SUCCESS =
             "%s has successfully been edited!";
+    private static final String MESSAGE_CYCLIC_DEPENDENCY_DETECTED =
+            "Cyclic dependency detected between %s and %s! "
+            + "Do not assign a super-tag as a sub-tag to the tag you are editing.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + COMMAND_TYPE
             + ": Edits an existing tag in Athena. You can add and/or remove contacts from a tag, and/or "
@@ -108,6 +111,13 @@ public class EditTagCommand extends Command {
         if (hasChildTagToAddAlreadyPresent) {
             throw new CommandException(String.format(MESSAGE_ADD_TAG_PRESENT, tagToEdit));
         }
+
+        for (Tag childTagToAdd : tagSetToAdd) {
+            if (model.isSubTagOf(childTagToAdd, tagToEdit)) {
+                throw new CommandException(String.format(MESSAGE_CYCLIC_DEPENDENCY_DETECTED, tagToEdit, childTagToAdd));
+            }
+        }
+
     }
 
     private static Set<Person> getPersonsAtIndices(Model model, Set<Index> indices) {

--- a/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
@@ -21,6 +21,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+/**
+ * Edits an existing tag in Athena.
+ * The tag can be assigned new child-tags or have existing child-tags removed.
+ * Additionally, edits can be made to the set of contacts containing the tag.
+ */
 public class EditTagCommand extends Command {
 
     public static final String COMMAND_WORD = CommandWord.EDIT.toString();
@@ -39,10 +44,13 @@ public class EditTagCommand extends Command {
     public static final String MESSAGE_CYCLIC_DEPENDENCY_DETECTED =
             "Cyclic dependency detected between %s and %s! "
             + "Do not assign a super-tag as a sub-tag to the tag you are editing.";
+    public static final String MESSAGE_NOT_EDITED =
+            "None of the edit fields have been properly specified! Please specify at least one";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + COMMAND_TYPE
             + ": Edits an existing tag in Athena. You can add and/or remove contacts from a tag, and/or "
-            + "add and/or remove child-tags from the same tag.\n\n"
+            + "add and/or remove child-tags from the same tag. "
+            + "At least one of the optional fields must be specified.\n\n"
             + "Parameters:\n"
             + PREFIX_NAME + "TAG_NAME\n"
             + "[" + PREFIX_INDEX + "INDEX_TO_ADD]...\n"
@@ -61,6 +69,14 @@ public class EditTagCommand extends Command {
     private final Set<Tag> tagSetToAdd;
     private final Set<Tag> tagSetToRemove;
 
+    /**
+     * Creates an EditTagCommand object that edits {@code tagToEdit}.
+     * For contacts found at indices in {@code indexSetToAdd}, {@code tagToEdit} is added to these contacts.
+     * For contacts found at indices in {@code indexSetToRemove}, {@code tagToEdit} is removed from these contacts.
+     * For the child-tag set of {@code tagToEdit}, tags in {@code tagSetToAdd} will be added and tags in
+     * {@code tagSetToRemove} will be removed.
+     * {@code tagToEdit}, and tags in {@code tagSetToAdd} and {@code tagSetToRemove} must already exist in Athena.
+     */
     public EditTagCommand(Tag tagToEdit, Set<Index> indexSetToAdd, Set<Index> indexSetToRemove,
             Set<Tag> tagSetToAdd, Set<Tag> tagSetToRemove) {
         requireAllNonNull(tagToEdit, indexSetToAdd, indexSetToRemove, tagSetToAdd, tagSetToRemove);
@@ -87,6 +103,15 @@ public class EditTagCommand extends Command {
         return new CommandResult(String.format(MESSAGE_SUCCESS, tagToEdit));
     }
 
+    /**
+     * Checks the validity of the command with the given model.
+     * Contact to have {@code tagToEdit} removed must have the tag prior to execution.
+     * Contact to have {@code tagToEdit} added must not have the tag prior to execution.
+     * Tags from {@code tagSetToRemove} must already be in the child-tag set of {@code tagToEdit} prior to execution.
+     * Tags from {@code tagSetToAdd} must not be in the child-tag set of {@code tagToEdit} prior to execution.
+     * Tags from {@code tagSetToAdd} that are to added as child-tag cannot be super-tags of {@code tagToEdit}.
+     * @throws CommandException if any of the conditions are violated.
+     */
     private void checkInputValidity(Model model) throws CommandException {
         boolean hasPersonToRemoveWithoutTag = getPersonsAtIndices(model, indexSetToRemove).stream()
                 .anyMatch(person -> !person.getTags().contains(tagToEdit));
@@ -120,31 +145,43 @@ public class EditTagCommand extends Command {
 
     }
 
+    /**
+     * Returns a set of person objects corresponding to the indices specified by {@code indices}.
+     */
     private static Set<Person> getPersonsAtIndices(Model model, Set<Index> indices) {
         return indices.stream()
                 .map(index -> index.getZeroBased())
                 .map(index -> model.getSortedFilteredPersonList().get(index))
                 .collect(Collectors.toSet());
-
     }
 
-    private void removeTagFromPersonsAtIndices(Model model) throws CommandException {
+    /**
+     * Removes {@code tagToEdit} from all persons specified by indices in {@code indexSetToRemove}.
+     */
+    private void removeTagFromPersonsAtIndices(Model model) {
         Set<Person> personSetToRemove = getPersonsAtIndices(model, indexSetToRemove);
         personSetToRemove.stream().forEach(person -> model.removePersonFromTag(tagToEdit, person));
     }
 
-    private void addTagToPersonsAtIndices(Model model) throws CommandException {
+    /**
+     * Adds {@code tagToEdit} to all persons specified by indices in {@code indexSetToAdd}.
+     */
+    private void addTagToPersonsAtIndices(Model model) {
         Set<Person> personSetToAdd = getPersonsAtIndices(model, indexSetToAdd);
         personSetToAdd.stream().forEach(person -> model.addPersonToTag(tagToEdit, person));
     }
 
-    private void removeChildTagsFromTag(Model model) throws CommandException {
-        Set<Tag> originalChildTagSet = model.getChildTags(tagToEdit);
+    /**
+     * Removes tags found in {@code tagSetToRemove} from the child-tag set of {@code tagToEdit}.
+     */
+    private void removeChildTagsFromTag(Model model) {
         tagSetToRemove.stream().forEach(tag -> model.removeChildTagFrom(tagToEdit, tag));
     }
 
-    private void addChildTagsFromTag(Model model) throws CommandException {
-        Set<Tag> originalChildTagSet = model.getChildTags(tagToEdit);
+    /**
+     * Adds tags found in {@code tagSetToAdd} to the child-tag set of {@code tagToEdit}.
+     */
+    private void addChildTagsFromTag(Model model) {
         tagSetToAdd.stream().forEach(tag -> model.addSubTagTo(tagToEdit, tag));
     }
 

--- a/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
@@ -193,7 +193,8 @@ public class EditTagCommand extends Command {
             return false;
         } else {
             EditTagCommand other = (EditTagCommand) o;
-            return other.indexSetToAdd.equals(indexSetToAdd)
+            return other.tagToEdit.equals(tagToEdit)
+                    && other.indexSetToAdd.equals(indexSetToAdd)
                     && other.indexSetToRemove.equals(indexSetToRemove)
                     && other.tagSetToAdd.equals(tagSetToAdd)
                     && other.tagSetToRemove.equals(tagSetToRemove);

--- a/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tags/EditTagCommand.java
@@ -1,5 +1,16 @@
 package seedu.address.logic.commands.tags;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
@@ -10,16 +21,6 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 /**
  * Edits an existing tag in Athena.

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -30,6 +30,7 @@ import seedu.address.logic.parser.events.FindEventCommandParser;
 import seedu.address.logic.parser.events.SortEventCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.tags.AddTagCommandParser;
+import seedu.address.logic.parser.tags.EditTagCommandParser;
 import seedu.address.logic.parser.tags.ViewTagCommandParser;
 
 /**
@@ -132,6 +133,9 @@ public class AddressBookParser {
 
             case ADD:
                 return new AddTagCommandParser().parse(arguments);
+
+            case EDIT:
+                return new EditTagCommandParser().parse(arguments);
 
             case LIST:
                 return new ListTagCommand();

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,6 +13,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_REMOVE_TAG = new Prefix("rt/");
     public static final Prefix PREFIX_INDEX = new Prefix("i/");
+    public static final Prefix PREFIX_REMOVE_INDEX = new Prefix("ri/");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
     public static final Prefix PREFIX_DATETIME = new Prefix("at/");
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -37,6 +37,9 @@ public class ParserUtil {
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
 
+    /**
+     * Parses {@code Collection<String> inputs} into a {@code Set<Index>}.
+     */
     public static Set<Index> parseIndices(Collection<String> inputs) throws ParseException {
         assert inputs != null;
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -37,6 +37,16 @@ public class ParserUtil {
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
 
+    public static Set<Index> parseIndices(Collection<String> inputs) throws ParseException {
+        assert inputs != null;
+
+        final Set<Index> indexSet = new HashSet<>();
+        for (String index : inputs) {
+            indexSet.add(parseIndex(index));
+        }
+        return indexSet;
+    }
+
     /**
      * Parses a {@code String name} into a {@code Name}.
      * Leading and trailing whitespaces will be trimmed.

--- a/src/main/java/seedu/address/logic/parser/tags/EditTagCommand.java
+++ b/src/main/java/seedu/address/logic/parser/tags/EditTagCommand.java
@@ -1,0 +1,154 @@
+package seedu.address.logic.parser.tags;
+
+import com.sun.scenario.effect.Blend;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
+import seedu.address.logic.commands.CommandWord;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+public class EditTagCommand extends Command {
+
+    public static final String COMMAND_WORD = CommandWord.EDIT.toString();
+    public static final String COMMAND_TYPE = CommandType.TAG.toString();
+
+    private static final String MESSAGE_REMOVE_CONTACT_DOES_NOT_HAVE_TAG =
+            "One of the specified indices to remove does not have %s as a tag";
+    private static final String MESSAGE_ADD_CONTACT_HAS_TAG =
+            "One of the specified indices to add already has %s as a tag";
+    private static final String MESSAGE_REMOVE_TAG_NOT_PRESENT =
+            "One of the specified tags to remove is already not a child-tag of %s";
+    private static final String MESSAGE_ADD_TAG_PRESENT =
+            "One of the specified tags to add is already a child-tag of %s";
+    private static final String MESSAGE_SUCCESS =
+            "%s has successfully been edited!";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " " + COMMAND_TYPE
+            + ": Edits an existing tag in Athena. You can add and/or remove contacts from a tag, and/or "
+            + "add and/or remove child-tags from the same tag.\n\n"
+            + "Parameters:\n"
+            + PREFIX_NAME + "TAG_NAME\n"
+            + "[" + PREFIX_INDEX + "INDEX_TO_ADD]...\n"
+            + "[" + PREFIX_REMOVE_INDEX + "INDEX_TO_REMOVE]...\n"
+            + "[" + PREFIX_TAG + "SUB_TAG_TO_ADD]...\n"
+            + "[" + PREFIX_REMOVE_TAG + "SUB_TAG_TO_REMOVE]...\n\n"
+            + "Example: " + COMMAND_WORD + " " + COMMAND_TYPE + " "
+            + PREFIX_INDEX + "1 "
+            + PREFIX_REMOVE_INDEX + "9 "
+            + PREFIX_TAG + "newchildtag "
+            + PREFIX_REMOVE_TAG + "oldchildtag";
+
+    private final Tag tagToEdit;
+    private final Set<Index> indexSetToAdd;
+    private final Set<Index> indexSetToRemove;
+    private final Set<Tag> tagSetToAdd;
+    private final Set<Tag> tagSetToRemove;
+
+    public EditTagCommand(Tag tagToEdit, Set<Index> indexSetToAdd, Set<Index> indexSetToRemove,
+            Set<Tag> tagSetToAdd, Set<Tag> tagSetToRemove) {
+        this.tagToEdit = tagToEdit;
+        this.indexSetToAdd = indexSetToAdd;
+        this.indexSetToRemove = indexSetToRemove;
+        this.tagSetToAdd = tagSetToAdd;
+        this.tagSetToRemove = tagSetToRemove;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        checkInputValidity(model);
+
+        removeTagFromPersonsAtIndices(model);
+        addTagToPersonsAtIndices(model);
+
+        removeChildTagsFromTag(model);
+        addChildTagsFromTag(model);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, tagToEdit));
+    }
+
+    private void checkInputValidity(Model model) throws CommandException {
+        boolean hasPersonToRemoveWithoutTag = getPersonsAtIndices(model, indexSetToRemove).stream()
+                .anyMatch(person -> !person.getTags().contains(tagToEdit));
+        if (hasPersonToRemoveWithoutTag) {
+            throw new CommandException(String.format(MESSAGE_REMOVE_CONTACT_DOES_NOT_HAVE_TAG, tagToEdit));
+        }
+
+        boolean hasPersonToAddWithTag = getPersonsAtIndices(model, indexSetToAdd).stream()
+                .anyMatch(person -> person.getTags().contains(tagToEdit));
+        if (hasPersonToAddWithTag) {
+            throw new CommandException(String.format(MESSAGE_ADD_CONTACT_HAS_TAG, tagToEdit));
+        }
+
+        boolean hasChildTagToRemoveNotPresent = tagSetToRemove.stream()
+                .anyMatch(tag -> !model.getChildTags(tagToEdit).contains(tag));
+        if (hasChildTagToRemoveNotPresent) {
+            throw new CommandException(String.format(MESSAGE_REMOVE_TAG_NOT_PRESENT, tagToEdit));
+        }
+
+        boolean hasChildTagToAddAlreadyPresent = tagSetToAdd.stream()
+                .anyMatch(tag -> model.getChildTags(tagToEdit).contains(tag));
+        if (hasChildTagToAddAlreadyPresent) {
+            throw new CommandException(String.format(MESSAGE_ADD_TAG_PRESENT, tagToEdit));
+        }
+    }
+
+    private static Set<Person> getPersonsAtIndices(Model model, Set<Index> indices) {
+        return indices.stream()
+                .map(index -> index.getZeroBased())
+                .map(index -> model.getSortedFilteredPersonList().get(index))
+                .collect(Collectors.toSet());
+
+    }
+
+    private void removeTagFromPersonsAtIndices(Model model) throws CommandException {
+        Set<Person> personSetToRemove = getPersonsAtIndices(model, indexSetToRemove);
+        personSetToRemove.stream().forEach(person -> model.removePersonFromTag(tagToEdit, person));
+    }
+
+    private void addTagToPersonsAtIndices(Model model) throws CommandException {
+        Set<Person> personSetToAdd = getPersonsAtIndices(model, indexSetToAdd);
+        personSetToAdd.stream().forEach(person -> model.addPersonToTag(tagToEdit, person));
+    }
+
+    private void removeChildTagsFromTag(Model model) throws CommandException {
+        Set<Tag> originalChildTagSet = model.getChildTags(tagToEdit);
+        tagSetToRemove.stream().forEach(tag -> model.removeChildTagFrom(tagToEdit, tag));
+    }
+
+    private void addChildTagsFromTag(Model model) throws CommandException {
+        Set<Tag> originalChildTagSet = model.getChildTags(tagToEdit);
+        tagSetToAdd.stream().forEach(tag -> model.addSubTagTo(tagToEdit, tag));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        } else if (!(o instanceof EditTagCommand)) {
+            return false;
+        } else {
+            EditTagCommand other = (EditTagCommand) o;
+            return other.indexSetToAdd.equals(indexSetToAdd)
+                    && other.indexSetToRemove.equals(indexSetToRemove)
+                    && other.tagSetToAdd.equals(tagSetToAdd)
+                    && other.tagSetToRemove.equals(tagSetToRemove);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/tags/EditTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tags/EditTagCommandParser.java
@@ -1,5 +1,15 @@
 package seedu.address.logic.parser.tags;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Set;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.tags.EditTagCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
@@ -8,16 +18,6 @@ import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
-
-import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 /**
  * Parses input arugments and creates a new EditTagCommand object.

--- a/src/main/java/seedu/address/logic/parser/tags/EditTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tags/EditTagCommandParser.java
@@ -20,7 +20,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
 /**
- * Parses input arugments and creates a new EditTagCommand object.
+ * Parses input arguments and creates a new EditTagCommand object.
  */
 public class EditTagCommandParser implements Parser<EditTagCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/tags/EditTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tags/EditTagCommandParser.java
@@ -33,7 +33,7 @@ public class EditTagCommandParser implements Parser<EditTagCommand> {
         if (!hasTagSpecified) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditTagCommand.MESSAGE_USAGE));
         }
-        Tag tagToEdit = ParserUtil.parseTag(argumentMultimap.getValue(PREFIX_NAME).get(), true);
+        Tag tagToEdit = ParserUtil.parseTag(argumentMultimap.getValue(PREFIX_NAME).get());
 
         Set<Index> indexSetToAdd = ParserUtil.parseIndices(argumentMultimap.getAllValues(PREFIX_INDEX));
         Set<Index> indexSetToRemove = ParserUtil.parseIndices(argumentMultimap.getAllValues(PREFIX_REMOVE_INDEX));

--- a/src/main/java/seedu/address/logic/parser/tags/EditTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tags/EditTagCommandParser.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser.tags;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.tags.EditTagCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+public class EditTagCommandParser implements Parser<EditTagCommand> {
+
+    @Override
+    public EditTagCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        ArgumentMultimap argumentMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_INDEX, PREFIX_REMOVE_INDEX,
+                        PREFIX_TAG, PREFIX_REMOVE_TAG);
+
+        boolean hasTagSpecified = argumentMultimap.getValue(PREFIX_NAME).isPresent();
+        if (!hasTagSpecified) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditTagCommand.MESSAGE_USAGE));
+        }
+        Tag tagToEdit = ParserUtil.parseTag(argumentMultimap.getValue(PREFIX_NAME).get(), true);
+
+        Set<Index> indexSetToAdd = ParserUtil.parseIndices(argumentMultimap.getAllValues(PREFIX_INDEX));
+        Set<Index> indexSetToRemove = ParserUtil.parseIndices(argumentMultimap.getAllValues(PREFIX_REMOVE_INDEX));
+
+        Set<Tag> tagSetToAdd = ParserUtil.parseTags(argumentMultimap.getAllValues(PREFIX_TAG));
+        Set<Tag> tagSetToRemove = ParserUtil.parseTags(argumentMultimap.getAllValues(PREFIX_REMOVE_TAG));
+
+        return new EditTagCommand(tagToEdit, indexSetToAdd, indexSetToRemove, tagSetToAdd, tagSetToRemove);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/tags/EditTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tags/EditTagCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser.tags;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.tags.EditTagCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -19,9 +20,19 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+/**
+ * Parses input arugments and creates a new EditTagCommand object.
+ */
 public class EditTagCommandParser implements Parser<EditTagCommand> {
 
-    @Override
+    /**
+     * Parses the given string {@code args} in the context of an EditTagCommand and returns it for execution.
+     * A tag name must be specified under PREFIX_NAME to indicate the tag to be edited.
+     * Separate sets are generated for indices of contacts to be added, indices of contacts to be removed,
+     * tags to be added as child-tags, and child-tags to be removed.
+     * There must be at least one optional field to edit (i.e. all sets cannot be empty).
+     * @throws ParseException if any of the required conditions are not met
+     */
     public EditTagCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
@@ -40,6 +51,12 @@ public class EditTagCommandParser implements Parser<EditTagCommand> {
 
         Set<Tag> tagSetToAdd = ParserUtil.parseTags(argumentMultimap.getAllValues(PREFIX_TAG));
         Set<Tag> tagSetToRemove = ParserUtil.parseTags(argumentMultimap.getAllValues(PREFIX_REMOVE_TAG));
+
+        boolean isAllSetsEmpty = indexSetToAdd.isEmpty() && indexSetToRemove.isEmpty()
+                && tagSetToAdd.isEmpty() && tagSetToRemove.isEmpty();
+        if (isAllSetsEmpty) {
+            throw new ParseException(EditTagCommand.MESSAGE_NOT_EDITED);
+        }
 
         return new EditTagCommand(tagToEdit, indexSetToAdd, indexSetToRemove, tagSetToAdd, tagSetToRemove);
     }

--- a/src/main/java/seedu/address/logic/parser/tags/EditTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tags/EditTagCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser.tags;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.tags.EditTagCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -116,6 +116,20 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Removes {@code tag} from the designated {@code person}.
+     */
+    public void removePersonFromTag(Tag tag, Person person) {
+        Set<Tag> newTagSet = new HashSet<>(person.getTags());
+        newTagSet.remove(tag);
+        Person editedPerson = new Person(person.getName(),
+                person.getPhone(),
+                person.getEmail(),
+                person.getAddress(),
+                newTagSet);
+        setPerson(person, editedPerson);
+    }
+
+    /**
      * Replaces the given person {@code target} in the list with {@code editedPerson}.
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -177,6 +177,11 @@ public interface Model {
     Set<Tag> getSuperTags();
 
     /**
+     * Returns a set of all child-tags of {@code tag}.
+     */
+    Set<Tag> getChildTags(Tag tag);
+
+    /**
      * Returns a set of all tags below the provided {@code tag} in the tag hierarchy.
      * I.e. all sub-tags, all sub-tags of those sub-tags, etc.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -216,6 +216,11 @@ public interface Model {
      */
     void removeChildTagFrom(Tag parentTag, Tag childTag);
 
+    /**
+     * Returns true if {@code subTag} is a sub-tag of {@code superTag}.
+     */
+    boolean isSubTagOf(Tag superTag, Tag subTag);
+
     // Filter/sort-list methods
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -134,16 +134,6 @@ public interface Model {
      */
     void addEvent(Event event);
 
-    /**
-     * Adds {@code person} to {@code tag}.
-     * {@code person} will also reflect this change with a new {@code tag}.
-     */
-    void addPersonToTag(Tag tag, Person person);
-
-    /**
-     * Adds {@code subTag} as a sub-tag of {@code superTag}.
-     */
-    void addSubTagTo(Tag superTag, Tag subTag);
 
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
@@ -198,6 +188,28 @@ public interface Model {
      * I.e. all persons with either {@code tag}, and/or any of its sub-tags, sub-tag of sub-tags, etc.
      */
     Set<Person> getPersonsRecursive(Tag tag);
+
+    /**
+     * Adds {@code person} to {@code tag}.
+     * {@code person} will also reflect this change with a new {@code tag}.
+     */
+    void addPersonToTag(Tag tag, Person person);
+
+    /**
+     * Removes {@code person} from {@code tag}.
+     * {@code person} will also reflect this change with {@code tag} removed.
+     */
+    void removePersonFromTag(Tag tag, Person person);
+
+    /**
+     * Adds {@code subTag} as a sub-tag of {@code superTag}.
+     */
+    void addSubTagTo(Tag superTag, Tag subTag);
+
+    /**
+     * Removes {@code childTag} as a child-tag of {@code parentTag}.
+     */
+    void removeChildTagFrom(Tag parentTag, Tag childTag);
 
     // Filter/sort-list methods
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -286,6 +286,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public Set<Tag> getChildTags(Tag tag) {
+        return tagTree.getSubTagsOf(tag);
+    }
+
+    @Override
     public Set<Tag> getSubTagsRecursive(Tag tag) {
         return tagTree.getSubTagsRecursive(tag);
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -210,8 +210,18 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void removeChildTagFrom(Tag parentTag, Tag childTag) {
+        tagTree.removeSubTagFrom(parentTag, childTag);
+    }
+
+    @Override
     public void addPersonToTag(Tag tag, Person person) {
         addressBook.addPersonToTag(tag, person);
+    }
+
+    @Override
+    public void removePersonFromTag(Tag tag, Person person) {
+        addressBook.removePersonFromTag(tag, person);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -215,6 +215,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean isSubTagOf(Tag superTag, Tag subTag) {
+        return tagTree.isSubTagOf(superTag, subTag);
+
+    }
+
+    @Override
     public void addPersonToTag(Tag tag, Person person) {
         addressBook.addPersonToTag(tag, person);
     }

--- a/src/main/java/seedu/address/model/tag/TagTreeImpl.java
+++ b/src/main/java/seedu/address/model/tag/TagTreeImpl.java
@@ -1,5 +1,7 @@
 package seedu.address.model.tag;
 
+import seedu.address.model.tag.exceptions.TagCyclicDependencyException;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -103,7 +105,7 @@ public class TagTreeImpl extends TagTree {
         assert !superTag.equals(Tag.ALL_TAGS_TAG) && !subTag.equals(Tag.ALL_TAGS_TAG);
 
         if (isSubTagOf(subTag, superTag)) {
-            throw new IllegalArgumentException(String.format(MESSAGE_CYCLIC_RELATIONSHIP, superTag, subTag));
+            throw new TagCyclicDependencyException(superTag, subTag);
         }
         addToMapSet(tagSubTagMap, superTag, subTag);
         addToMapSet(tagSuperTagMap, subTag, superTag);

--- a/src/main/java/seedu/address/model/tag/TagTreeImpl.java
+++ b/src/main/java/seedu/address/model/tag/TagTreeImpl.java
@@ -1,12 +1,12 @@
 package seedu.address.model.tag;
 
-import seedu.address.model.tag.exceptions.TagCyclicDependencyException;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+
+import seedu.address.model.tag.exceptions.TagCyclicDependencyException;
 
 /**
  * A concrete implementation of the TagTree. It uses two HashMaps to keep track of the two-way relationship of tags.

--- a/src/main/java/seedu/address/model/tag/TagTreeImpl.java
+++ b/src/main/java/seedu/address/model/tag/TagTreeImpl.java
@@ -182,7 +182,6 @@ public class TagTreeImpl extends TagTree {
 
         boolean hasSubTagAsDirectChild = tagSubTagMap.get(superTag).contains(subTag);
         if (hasSubTagAsDirectChild) {
-            System.out.println(superTag + " " + subTag);
             return true;
         }
 

--- a/src/main/java/seedu/address/model/tag/exceptions/TagCyclicDependencyException.java
+++ b/src/main/java/seedu/address/model/tag/exceptions/TagCyclicDependencyException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.tag.exceptions;
+
+import seedu.address.model.tag.Tag;
+
+public class TagCyclicDependencyException extends Exception {
+
+    public TagCyclicDependencyException(Tag subTag, Tag superTag) {
+        super(String.format("Cyclic dependency detected! Avoid adding %s as a sub-tag of %s", superTag, subTag));
+    }
+
+}

--- a/src/main/java/seedu/address/model/tag/exceptions/TagCyclicDependencyException.java
+++ b/src/main/java/seedu/address/model/tag/exceptions/TagCyclicDependencyException.java
@@ -2,7 +2,7 @@ package seedu.address.model.tag.exceptions;
 
 import seedu.address.model.tag.Tag;
 
-public class TagCyclicDependencyException extends Exception {
+public class TagCyclicDependencyException extends RuntimeException {
 
     public TagCyclicDependencyException(Tag subTag, Tag superTag) {
         super(String.format("Cyclic dependency detected! Avoid adding %s as a sub-tag of %s", superTag, subTag));

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -200,6 +200,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public Set<Tag> getChildTags(Tag tag) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public Set<Tag> getSubTagsRecursive(Tag tag) {
         throw new AssertionError("This method should not be called.");
     }

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -86,7 +86,17 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public void removePersonFromTag(Tag tag, Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void addSubTagTo(Tag superTag, Tag subTag) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void removeChildTagFrom(Tag parentTag, Tag childTag) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -101,6 +101,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public boolean isSubTagOf(Tag superTag, Tag subTag) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void setAddressBook(ReadOnlyAddressBook newData) {
         throw new AssertionError("This method should not be called.");
     }

--- a/src/test/java/seedu/address/logic/commands/tags/EditTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/tags/EditTagCommandTest.java
@@ -1,0 +1,167 @@
+package seedu.address.logic.commands.tags;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.model.ContactTagIntegrationManagerTest.PERSON_CS1231S_1;
+import static seedu.address.model.ContactTagIntegrationManagerTest.buildTestContactTagIntegrationManager;
+import static seedu.address.testutil.TagTreeUtil.TAG_ARCHITECTURE;
+import static seedu.address.testutil.TagTreeUtil.TAG_CS1231S;
+import static seedu.address.testutil.TagTreeUtil.TAG_CS2040S_NOT_TREE;
+import static seedu.address.testutil.TagTreeUtil.TAG_MA1101R;
+import static seedu.address.testutil.TagTreeUtil.TAG_NUS;
+import static seedu.address.testutil.TagTreeUtil.TAG_SCIENCE;
+import static seedu.address.testutil.TagTreeUtil.TAG_SCIENCE_COMP;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javafx.collections.ObservableList;
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ModelStub;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.ContactTagIntegrationManager;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.TagTree;
+
+
+public class EditTagCommandTest {
+
+    @Test
+    public void execute_tagToEditNotPresent_throwsCommandException() {
+        ModelStubWithTagAndPersons model = new ModelStubWithTagAndPersons();
+        EditTagCommand command = new EditTagCommand(TAG_CS2040S_NOT_TREE, Set.of(), Set.of(),
+                Set.of(TAG_CS1231S), Set.of());
+        assertThrows(CommandException.class, () -> command.execute(model));
+    }
+
+    @Test
+    public void execute_argumentNotValid_throwsCommandException() {
+        ModelStubWithTagAndPersons model = new ModelStubWithTagAndPersons();
+
+        // Remove person who already does not have the tag
+        EditTagCommand command = new EditTagCommand(TAG_MA1101R, Set.of(), Set.of(Index.fromZeroBased(0)),
+                Set.of(), Set.of());
+        assertThrows(CommandException.class, () -> command.execute(model));
+        // Add person who already has the tag
+        EditTagCommand command2 = new EditTagCommand(TAG_CS1231S, Set.of(Index.fromZeroBased(0)), Set.of(),
+                Set.of(), Set.of());
+        assertThrows(CommandException.class, () -> command2.execute(model));
+        // Remove child-tag that is not a child-tag
+        EditTagCommand command3 = new EditTagCommand(TAG_SCIENCE, Set.of(), Set.of(),
+                Set.of(), Set.of(TAG_NUS));
+        assertThrows(CommandException.class, () -> command3.execute(model));
+        // Add child-tag that is already a child-tag
+        EditTagCommand command4 = new EditTagCommand(TAG_SCIENCE, Set.of(), Set.of(),
+                Set.of(TAG_SCIENCE_COMP), Set.of());
+        assertThrows(CommandException.class, () -> command4.execute(model));
+    }
+
+    @Test
+    public void execute_attemptedCyclicTagAdded_throwsCommandException() {
+        ModelStubWithTagAndPersons model = new ModelStubWithTagAndPersons();
+        EditTagCommand command = new EditTagCommand(TAG_SCIENCE, Set.of(), Set.of(),
+                Set.of(TAG_NUS), Set.of());
+        EditTagCommand command2 = new EditTagCommand(TAG_MA1101R, Set.of(), Set.of(),
+                Set.of(TAG_NUS), Set.of());
+        assertThrows(CommandException.class, () -> command.execute(model));
+        assertThrows(CommandException.class, () -> command2.execute(model));
+    }
+
+    @Test
+    public void execute_validCommand_success() throws Exception {
+        ModelStubWithTagAndPersons model = new ModelStubWithTagAndPersons();
+        EditTagCommand command = new EditTagCommand(TAG_CS1231S, Set.of(Index.fromZeroBased(2)),
+                Set.of(Index.fromZeroBased(0)), Set.of(TAG_MA1101R), Set.of());
+        command.execute(model);
+        // Test case depends on the underlying order in ContactTagIntegrationManagerTest
+        assertFalse(model.getPersonsWithTag(TAG_CS1231S).contains(PERSON_CS1231S_1));
+        assertTrue(model.getPersonsWithTag(TAG_CS1231S).size() == 2);
+        assertTrue(model.getChildTags(TAG_CS1231S).contains(TAG_MA1101R));
+
+        Set<Tag> newTagSet = new HashSet<>(PERSON_CS1231S_1.getTags());
+        newTagSet.remove(TAG_CS1231S);
+        Person expectedPerson = new Person(PERSON_CS1231S_1.getName(),
+                PERSON_CS1231S_1.getPhone(),
+                PERSON_CS1231S_1.getEmail(),
+                PERSON_CS1231S_1.getAddress(),
+                newTagSet);
+        assertTrue(model.hasPerson(expectedPerson));
+
+        command = new EditTagCommand(TAG_NUS, Set.of(), Set.of(), Set.of(), Set.of(TAG_ARCHITECTURE));
+        command.execute(model);
+        assertFalse(model.getChildTags(TAG_NUS).contains(TAG_ARCHITECTURE));
+    }
+
+    private class ModelStubWithTagAndPersons extends ModelStub {
+        private ContactTagIntegrationManager manager = buildTestContactTagIntegrationManager();
+        private AddressBook addressBook = manager.getAddressBook();
+        private TagTree tagTree = manager.getTagTree();
+
+        @Override
+        public void addSubTagTo(Tag superTag, Tag subTag) {
+            tagTree.addSubTagTo(superTag, subTag);
+        }
+
+        @Override
+        public void addPersonToTag(Tag tag, Person person) {
+            addressBook.addPersonToTag(tag, person);
+        }
+
+        @Override
+        public boolean hasTag(Tag tag) {
+            return manager.hasTag(tag);
+        }
+
+        @Override
+        public void removePersonFromTag(Tag tag, Person person) {
+            addressBook.removePersonFromTag(tag, person);
+        }
+
+        @Override
+        public void removeChildTagFrom(Tag parentTag, Tag childTag) {
+            tagTree.removeSubTagFrom(parentTag, childTag);
+        }
+
+        @Override
+        public ObservableList<Person> getSortedFilteredPersonList() {
+            return addressBook.getPersonList();
+        }
+
+        @Override
+        public TagTree getTagTree() {
+            return tagTree;
+        }
+
+        @Override
+        public AddressBook getAddressBook() {
+            return addressBook;
+        }
+
+        @Override
+        public Set<Tag> getChildTags(Tag tag) {
+            return tagTree.getSubTagsOf(tag);
+        }
+
+        @Override
+        public boolean isSubTagOf(Tag superTag, Tag subTag) {
+            return tagTree.isSubTagOf(superTag, subTag);
+        }
+
+        @Override
+        public Set<Person> getPersonsWithTag(Tag tag) {
+            return addressBook.getPersonsWithTag(tag);
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            return addressBook.hasPerson(person);
+        }
+
+    }
+
+
+}

--- a/src/test/java/seedu/address/logic/commands/tags/EditTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/tags/EditTagCommandTest.java
@@ -16,8 +16,9 @@ import static seedu.address.testutil.TagTreeUtil.TAG_SCIENCE_COMP;
 import java.util.HashSet;
 import java.util.Set;
 
-import javafx.collections.ObservableList;
 import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ModelStub;
 import seedu.address.logic.commands.exceptions.CommandException;

--- a/src/test/java/seedu/address/logic/parser/tags/EditTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/tags/EditTagCommandParserTest.java
@@ -1,15 +1,17 @@
 package seedu.address.logic.parser.tags;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.tags.EditTagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class EditTagCommandParserTest {
 

--- a/src/test/java/seedu/address/logic/parser/tags/EditTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/tags/EditTagCommandParserTest.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.parser.tags;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.tags.EditTagCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class EditTagCommandParserTest {
+
+    private static final String TAG_NAME_VALID = " n/testtag";
+    private static final Tag TAG_VALID = new Tag("testtag");
+    private static final String TAG_NAME_INVALID = "n/   ";
+
+    private static final String INDEX_STRING_ONE = " i/1";
+    private static final String INDEX_STRING_TWO = " i/2";
+    private static final Set<Index> INDEX_SET = Set.of(Index.fromOneBased(1), Index.fromOneBased(2));
+
+    private static final String REMOVE_INDEX_STRING_ONE = " ri/1";
+    private static final String REMOVE_INDEX_STRING_TWO = " ri/2";
+    private static final String REMOVE_INDEX_STRING_INVALID = " ri/c";
+    private static final Set<Index> REMOVE_INDEX_SET = Set.of(Index.fromOneBased(1), Index.fromOneBased(2));
+
+    private static final String TAG_STRING_CS2030 = " t/cs2030";
+    private static final String TAG_STRING_CS2040 = " t/cs2040";
+    private static final String TAG_STRING_EMPTY = " t/   ";
+    private static final Set<Tag> TAG_SET = Set.of(new Tag("cs2030"), new Tag("cs2040"));
+
+    private static final String REMOVE_TAG_STRING_CS2030 = " rt/cs2030";
+    private static final String REMOVE_TAG_STRING_CS2040 = " rt/cs2040";
+    private static final String REMOVE_TAG_STRING_INVALID = " rt/+-*/";
+    private static final Set<Tag> REMOVE_TAG_SET = Set.of(new Tag("cs2030"), new Tag("cs2040"));
+
+    private EditTagCommandParser parser = new EditTagCommandParser();
+
+    @Test
+    public void parse_missingName_throwParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(REMOVE_TAG_STRING_CS2030 + INDEX_STRING_ONE));
+        assertThrows(ParseException.class, () -> parser.parse(REMOVE_TAG_STRING_CS2030 + TAG_NAME_INVALID
+                + INDEX_STRING_ONE));
+    }
+
+    @Test
+    public void parse_noEditArguments_throwParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(TAG_NAME_VALID));
+        assertThrows(ParseException.class, () -> parser.parse(TAG_NAME_VALID + TAG_STRING_EMPTY));
+    }
+
+    @Test
+    public void parse_invalidEditArgumentFormat_throwParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(TAG_NAME_VALID + REMOVE_INDEX_STRING_INVALID));
+        assertThrows(ParseException.class, () -> parser.parse(TAG_NAME_VALID + TAG_STRING_CS2030
+                + REMOVE_TAG_STRING_INVALID));
+    }
+
+    @Test
+    public void parse_validArguments_success() throws ParseException {
+        EditTagCommand expectedCommand = new EditTagCommand(TAG_VALID, INDEX_SET, Set.of(), TAG_SET, Set.of());
+        EditTagCommand actualCommand = parser.parse(TAG_NAME_VALID + INDEX_STRING_ONE + INDEX_STRING_TWO
+                + TAG_STRING_CS2030 + TAG_STRING_CS2040);
+        assertEquals(expectedCommand, actualCommand);
+
+        expectedCommand = new EditTagCommand(TAG_VALID, INDEX_SET, REMOVE_INDEX_SET, TAG_SET, REMOVE_TAG_SET);
+        assertEquals(expectedCommand, parser.parse(TAG_NAME_VALID + REMOVE_TAG_STRING_CS2030 + TAG_STRING_CS2040
+                + REMOVE_TAG_STRING_CS2040 + INDEX_STRING_TWO + INDEX_STRING_ONE + REMOVE_INDEX_STRING_ONE
+                + REMOVE_INDEX_STRING_TWO + TAG_STRING_CS2030));
+    }
+
+}

--- a/src/test/java/seedu/address/model/tag/TagTreeImplTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTreeImplTest.java
@@ -23,6 +23,8 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.tag.exceptions.TagCyclicDependencyException;
+
 public class TagTreeImplTest {
 
     @Test
@@ -82,7 +84,7 @@ public class TagTreeImplTest {
 
     @Test
     public void addSubTag_cyclicTag_errorThrown() {
-        assertThrows(IllegalArgumentException.class, () -> buildTestTree().addSubTagTo(TAG_COMPUTING, TAG_NUS));
+        assertThrows(TagCyclicDependencyException.class, () -> buildTestTree().addSubTagTo(TAG_COMPUTING, TAG_NUS));
     }
 
     @Test


### PR DESCRIPTION
Allows editing of tags by
- adding and/or removing contacts from a tag
- adding and/or removing child-tags from a tag

Command also checks for cyclic tag relations and warns against it.

I realise that there is a need to define a child-tag (direct sub-tag) and a sub-tag (child-tag, child of child-tag, etc.). I will refactor and rename the method names and variable names in an upcoming pull request. 