### PR TITLE
Fix bugs involving EditContactCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/contacts/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contacts/EditContactCommand.java
@@ -173,8 +173,8 @@ public class EditContactCommand extends Command {
         private Phone phone;
         private Email email;
         private Address address;
-        private Set<Tag> tagsToAdd;
-        private Set<Tag> tagsToRemove;
+        private Set<Tag> tagsToAdd = Set.of();
+        private Set<Tag> tagsToRemove = Set.of();
 
         public EditPersonDescriptor() {}
 
@@ -195,7 +195,9 @@ public class EditContactCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tagsToAdd, tagsToRemove);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address)
+                    || !tagsToAdd.isEmpty()
+                    || !tagsToRemove.isEmpty();
         }
 
         public void setName(Name name) {

--- a/src/main/java/seedu/address/logic/parser/contacts/EditContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contacts/EditContactCommandParser.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 

--- a/src/main/java/seedu/address/logic/parser/contacts/EditContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contacts/EditContactCommandParser.java
@@ -86,8 +86,7 @@ public class EditContactCommandParser implements Parser<EditContactCommand> {
         if (tags.isEmpty()) {
             return Optional.empty();
         }
-        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseTags(tagSet, canBeWildcard));
+        return Optional.of(ParserUtil.parseTags(tags, canBeWildcard));
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/contacts/EditContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contacts/EditContactCommandTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands.contacts;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.contacts.EditContactCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Calendar;
 import seedu.address.model.Model;
@@ -152,6 +154,26 @@ public class EditContactCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editContactCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_removeTagNotPresent_throwCommandException() {
+        // Only one invalid tag
+        EditContactCommand editContactCommand = new EditContactCommand(INDEX_FIRST_PERSON,
+                new EditPersonDescriptorBuilder().withTagsToRemove("doesnotexist").build());
+        assertThrows(CommandException.class, () -> editContactCommand.execute(model));
+
+        // An invalid tag amongst other valid tag inputs
+        EditContactCommand editContactCommand2 = new EditContactCommand(INDEX_FIRST_PERSON,
+                new EditPersonDescriptorBuilder()
+                        .withTagsToRemove("doesnotexist", "*")
+                        .withName("someName").build());
+        EditContactCommand editContactCommand3 = new EditContactCommand(INDEX_FIRST_PERSON,
+                new EditPersonDescriptorBuilder()
+                        .withTagsToRemove("doesnotexist", "friends")
+                        .withName("someName").build());
+        assertThrows(CommandException.class, () -> editContactCommand2.execute(model));
+        assertThrows(CommandException.class, () -> editContactCommand3.execute(model));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -79,7 +79,8 @@ public class AddressBookParserTest {
         EditContactCommand command = (EditContactCommand) parser.parseCommand(EditContactCommand.COMMAND_WORD + " "
                 + EditContactCommand.COMMAND_TYPE + " " + INDEX_FIRST_PERSON.getOneBased() + " "
                 + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertEquals(new EditContactCommand(INDEX_FIRST_PERSON, descriptor), command);
+        EditContactCommand actualCommand = new EditContactCommand(INDEX_FIRST_PERSON, descriptor);
+        assertEquals(command, actualCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -53,9 +53,9 @@ public class PersonUtil {
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
         descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
 
-        descriptor.getTagsToAdd().ifPresent(tagsToAdd ->
+        descriptor.getTagsToAdd().filter(set -> !set.isEmpty()).ifPresent(tagsToAdd ->
                 convertTagsToStringDetails(sb, PREFIX_TAG, tagsToAdd));
-        descriptor.getTagsToRemove().ifPresent(tagsToRemove ->
+        descriptor.getTagsToRemove().filter(set -> !set.isEmpty()).ifPresent(tagsToRemove ->
                 convertTagsToStringDetails(sb, PREFIX_REMOVE_TAG, tagsToRemove));
 
         return sb.toString();


### PR DESCRIPTION
Issue was with a remnant of old AB3 code where an empty tag signified that all tags were to be removed. Fixes #95 

Added `CommandException` when a tag to be removed is already not on the contact. Fixes #137 