### PR TITLE
Update delete -c and delete -e to accept a list of indexes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -168,16 +168,16 @@ Format: `clear -c`
 
 #### Deleting a contact : `delete`
 
-Deletes the specified contact from Athena.
+Deletes the specified contact(s) from Athena.
 
-Format: `delete -c INDEX`
+Format: `delete -c CONTACT_INDEX_LIST`
 
-* Deletes the contact at the specified `INDEX`.
+* Deletes the contact(s) at the specified index(es) in `CONTACT_INDEX_LIST`.
 * The index refers to the index number shown in the displayed contact list.
 * The index **must be a positive integer** 1, 2, 3, …​
 
 Examples:
-* `list -c` followed by `delete -c 2` deletes the 2nd contact in Athena.
+* `list -c` followed by `delete -c 2,3` deletes the 2nd and 3rd contact in Athena.
 * `find -c n/Betsy` followed by `delete -c 1` deletes the 1st contact in the results of the `find` command.
 
 #### Editing a contact : `edit`
@@ -299,14 +299,14 @@ Format: `clear -e`
 
 Deletes the specified event from the event list.
 
-Format: `delete -e INDEX`
+Format: `delete -e EVENT_INDEX_LIST`
 
-* Deletes the event at the specified `INDEX`.
+* Deletes the event(s) at the specified index(es) in `EVENT_INDEX_LIST`.
 * The index refers to the index number shown in the displayed event list.
-* The index must be a positive integer 1, 2, 3, ...
+* The index **must be a positive integer** 1, 2, 3, ...
 
 Examples:
-* `list -e` followed by `delete -e 2` deletes the 2nd event in the event list.
+* `list -e` followed by `delete -e 2,3` deletes the 2nd and 3rd event in Athena.
 
 #### Editing an event : `edit`
 
@@ -521,8 +521,8 @@ Action | Format, Examples
 **Add Reminder** | `add -r [EVENT_INDEX] [in/DAYS]`
 **Clear Contacts** | `clear -c`
 **Clear Events** | `clear -e`
-**Delete Contact** | `delete -c INDEX`<br> e.g., `delete -c 3`
-**Delete Event** | `delete -e INDEX`<br> e.g., `delete -e 2`
+**Delete Contact** | `delete -c CONTACT_INDEX_LIST`<br> e.g., `delete -c 3,1,2`
+**Delete Event** | `delete -e EVENT_INDEX_LIST`<br> e.g., `delete -e 3,1,2`
 **Delete Tag** | `delete -t t/TAG_NAME [r/BOOLEAN]` <br> e.g., `delete -t t/computing r/t`
 **Edit Contact** | `edit -c INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]… [rt/TAG]…`<br> e.g.,`edit -c 2 n/James Lee e/jameslee@example.com`
 **Edit Event** | `edit -e INDEX [d/DESCRIPTION] [at/DATE_TIME] [ap/CONTACT_INDEX_LIST] [rp/ATTENDEE_INDEX_LIST]`<br> e.g., `edit -e 1 d/CS2101 Tutorial at/23-10-1234 12:30 ap/1,2,3 rp/1,2`

--- a/src/main/java/seedu/address/logic/commands/contacts/DeleteContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contacts/DeleteContactCommand.java
@@ -26,8 +26,10 @@ public class DeleteContactCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + COMMAND_TYPE
             + ": Deletes the person identified by the index number used in the displayed person list.\n\n"
-            + "Parameters: CONTACT_INDEX_LIST (must be positive integers)\n\n"
-            + "Example: " + COMMAND_WORD + " " + COMMAND_TYPE + " 1";
+            + "Parameters: CONTACT_INDEX_LIST (must be positive integer(s))\n\n"
+            + "Examples:\n"
+            + COMMAND_WORD + " " + COMMAND_TYPE + " 1" + "\n"
+            + COMMAND_WORD + " " + COMMAND_TYPE + " 1,2";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person(s): %1$s";
 
@@ -42,7 +44,7 @@ public class DeleteContactCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getSortedFilteredPersonList();
 
-        StringBuilder personsStringBuilder = new StringBuilder().append("The following contacts is/are deleted:");
+        StringBuilder personsStringBuilder = new StringBuilder();
 
         for (Index targetIndexes : targetIndexes) {
             if (targetIndexes.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/address/logic/commands/contacts/DeleteContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contacts/DeleteContactCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands.contacts;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import seedu.address.commons.core.Messages;
@@ -25,15 +26,15 @@ public class DeleteContactCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + COMMAND_TYPE
             + ": Deletes the person identified by the index number used in the displayed person list.\n\n"
-            + "Parameters: INDEX (must be a positive integer)\n\n"
+            + "Parameters: CONTACT_INDEX_LIST (must be positive integers)\n\n"
             + "Example: " + COMMAND_WORD + " " + COMMAND_TYPE + " 1";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person(s): %1$s";
 
-    private final Index targetIndex;
+    private final ArrayList<Index> targetIndexes;
 
-    public DeleteContactCommand(Index targetIndex) {
-        this.targetIndex = targetIndex;
+    public DeleteContactCommand(ArrayList<Index> targetIndexes) {
+        this.targetIndexes = targetIndexes;
     }
 
     @Override
@@ -41,19 +42,24 @@ public class DeleteContactCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getSortedFilteredPersonList();
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-        }
+        StringBuilder personsStringBuilder = new StringBuilder().append("The following contacts is/are deleted:");
 
-        Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
+        for (Index targetIndexes : targetIndexes) {
+            if (targetIndexes.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+
+            Person personToDelete = lastShownList.get(targetIndexes.getZeroBased());
+            model.deletePerson(personToDelete);
+            personsStringBuilder.append("\n\n" + personToDelete);
+        }
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personsStringBuilder.toString()));
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DeleteContactCommand // instanceof handles nulls
-                && targetIndex.equals(((DeleteContactCommand) other).targetIndex)); // state check
+                && targetIndexes.equals(((DeleteContactCommand) other).targetIndexes)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/events/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/events/DeleteEventCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands.events;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import seedu.address.commons.core.Messages;
@@ -25,15 +26,17 @@ public class DeleteEventCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + COMMAND_TYPE
             + ": Deletes the event identified by the index number used in the displayed event list.\n\n"
-            + "Parameters: INDEX (must be a positive integer)\n\n"
-            + "Example: " + COMMAND_WORD + " " + COMMAND_TYPE + " 1";
+            + "Parameters: EVENT_INDEX_LIST (must be positive integer(s))\n\n"
+            + "Examples:\n"
+            + COMMAND_WORD + " " + COMMAND_TYPE + " 1" + "\n"
+            + COMMAND_WORD + " " + COMMAND_TYPE + " 1,2";
 
-    public static final String MESSAGE_DELETE_EVENT_SUCCESS = "Deleted Event: %1$s";
+    public static final String MESSAGE_DELETE_EVENT_SUCCESS = "Deleted Event(s): %1$s";
 
-    private final Index targetIndex;
+    private final ArrayList<Index> targetIndexes;
 
-    public DeleteEventCommand(Index targetIndex) {
-        this.targetIndex = targetIndex;
+    public DeleteEventCommand(ArrayList<Index> targetIndexes) {
+        this.targetIndexes = targetIndexes;
     }
 
     @Override
@@ -41,19 +44,24 @@ public class DeleteEventCommand extends Command {
         requireNonNull(model);
         List<Event> lastShownList = model.getSortedFilteredEventList();
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
-        }
+        StringBuilder eventsStringBuilder = new StringBuilder();
 
-        Event eventToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deleteEvent(eventToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_EVENT_SUCCESS, eventToDelete));
+        for (Index targetIndex : targetIndexes) {
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+            }
+
+            Event eventToDelete = lastShownList.get(targetIndex.getZeroBased());
+            model.deleteEvent(eventToDelete);
+            eventsStringBuilder.append("\n\n" + eventToDelete);
+        }
+        return new CommandResult(String.format(MESSAGE_DELETE_EVENT_SUCCESS, eventsStringBuilder.toString()));
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DeleteEventCommand // instanceof handles nulls
-                && targetIndex.equals(((DeleteEventCommand) other).targetIndex)); // state check
+                && targetIndexes.equals(((DeleteEventCommand) other).targetIndexes)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/events/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/events/EditEventCommand.java
@@ -133,7 +133,7 @@ public class EditEventCommand extends Command {
         if (editEventDescriptor.getPersonsToRemove().isPresent()) {
             ArrayList<Index> indexArrayList = editEventDescriptor.getPersonsToRemove().get();
             // sorting based on biggest index first, so as to not remove the wrong persons
-            indexArrayList.sort((current, other) -> other.getZeroBased() - current.getOneBased());
+            indexArrayList.sort((current, other) -> other.getZeroBased() - current.getZeroBased());
             for (Index index : indexArrayList) {
                 tempAssociatedPersons.remove(index.getZeroBased());
             }

--- a/src/main/java/seedu/address/logic/parser/contacts/DeleteContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contacts/DeleteContactCommandParser.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser.contacts;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.ArrayList;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.contacts.DeleteContactCommand;
 import seedu.address.logic.parser.Parser;
@@ -20,8 +22,9 @@ public class DeleteContactCommandParser implements Parser<DeleteContactCommand> 
      */
     public DeleteContactCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteContactCommand(index);
+            ArrayList<Index> indexes = ParserUtil.parseIndexes(args);
+            indexes.sort((current, other) -> other.getZeroBased() - current.getZeroBased());
+            return new DeleteContactCommand(indexes);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteContactCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/events/DeleteEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/events/DeleteEventCommandParser.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser.events;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.ArrayList;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.events.DeleteEventCommand;
 import seedu.address.logic.parser.Parser;
@@ -20,8 +22,9 @@ public class DeleteEventCommandParser implements Parser<DeleteEventCommand> {
      */
     public DeleteEventCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteEventCommand(index);
+            ArrayList<Index> indexes = ParserUtil.parseIndexes(args);
+            indexes.sort((current, other) -> other.getZeroBased() - current.getZeroBased());
+            return new DeleteEventCommand(indexes);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteEventCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -106,13 +106,13 @@ public class Person {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getName())
-                .append(" Phone: ")
+                .append("\nPhone: ")
                 .append(getPhone())
-                .append(" Email: ")
+                .append("\nEmail: ")
                 .append(getEmail())
-                .append(" Address: ")
+                .append("\nAddress: ")
                 .append(getAddress())
-                .append(" Tags: ");
+                .append("\nTags: ");
         getTags().forEach(builder::append);
         return builder.toString();
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteEventCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_EVENT;
 
 import java.util.ArrayList;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;

--- a/src/test/java/seedu/address/logic/commands/DeleteEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteEventCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalEvents.getTypicalCalendar;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_EVENT;
 
+import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
@@ -30,9 +31,12 @@ public class DeleteEventCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Event eventToDelete = model.getSortedFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
-        DeleteEventCommand deleteEventCommand = new DeleteEventCommand(INDEX_FIRST_EVENT);
 
-        String expectedMessage = String.format(DeleteEventCommand.MESSAGE_DELETE_EVENT_SUCCESS, eventToDelete);
+        ArrayList<Index> indexes = new ArrayList<>();
+        indexes.add(INDEX_FIRST_EVENT);
+        DeleteEventCommand deleteEventCommand = new DeleteEventCommand(indexes);
+
+        String expectedMessage = String.format(DeleteEventCommand.MESSAGE_DELETE_EVENT_SUCCESS, "\n\n" + eventToDelete);
 
         ModelManager expectedModel = new ModelManagerBuilder().withCalendar(model.getCalendar()).build();
         expectedModel.deleteEvent(eventToDelete);
@@ -43,7 +47,10 @@ public class DeleteEventCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getSortedFilteredEventList().size() + 1);
-        DeleteEventCommand deleteEventCommand = new DeleteEventCommand(outOfBoundIndex);
+
+        ArrayList<Index> indexes = new ArrayList<>();
+        indexes.add(outOfBoundIndex);
+        DeleteEventCommand deleteEventCommand = new DeleteEventCommand(indexes);
 
         assertCommandFailureEvent(deleteEventCommand, model, Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
     }
@@ -53,9 +60,12 @@ public class DeleteEventCommandTest {
         showEventAtIndex(model, INDEX_FIRST_EVENT);
 
         Event eventToDelete = model.getSortedFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
-        DeleteEventCommand deleteEventCommand = new DeleteEventCommand(INDEX_FIRST_EVENT);
 
-        String expectedMessage = String.format(DeleteEventCommand.MESSAGE_DELETE_EVENT_SUCCESS, eventToDelete);
+        ArrayList<Index> indexes = new ArrayList<>();
+        indexes.add(INDEX_FIRST_EVENT);
+        DeleteEventCommand deleteEventCommand = new DeleteEventCommand(indexes);
+
+        String expectedMessage = String.format(DeleteEventCommand.MESSAGE_DELETE_EVENT_SUCCESS, "\n\n" + eventToDelete);
         Model expectedModel = new ModelManagerBuilder().withCalendar(model.getCalendar()).build();
         expectedModel.deleteEvent(eventToDelete);
         showNoEvent(expectedModel);
@@ -71,21 +81,27 @@ public class DeleteEventCommandTest {
         // ensures that outOfBoundIndex is still in bounds of calendar list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getCalendar().getEventList().size());
 
-        DeleteEventCommand deleteEventCommand = new DeleteEventCommand(outOfBoundIndex);
+        ArrayList<Index> indexes = new ArrayList<>();
+        indexes.add(outOfBoundIndex);
+        DeleteEventCommand deleteEventCommand = new DeleteEventCommand(indexes);
 
         assertCommandFailureEvent(deleteEventCommand, model, Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeleteEventCommand deleteFirstCommand = new DeleteEventCommand(INDEX_FIRST_EVENT);
-        DeleteEventCommand deleteSecondCommand = new DeleteEventCommand(INDEX_SECOND_EVENT);
+        ArrayList<Index> indexes1 = new ArrayList<>();
+        indexes1.add(INDEX_FIRST_EVENT);
+        DeleteEventCommand deleteFirstCommand = new DeleteEventCommand(indexes1);
+        ArrayList<Index> indexes2 = new ArrayList<>();
+        indexes2.add(INDEX_SECOND_EVENT);
+        DeleteEventCommand deleteSecondCommand = new DeleteEventCommand(indexes2);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteEventCommand deleteFirstCommandCopy = new DeleteEventCommand(INDEX_FIRST_EVENT);
+        DeleteEventCommand deleteFirstCommandCopy = new DeleteEventCommand(indexes1);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/contacts/DeleteContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contacts/DeleteContactCommandTest.java
@@ -35,7 +35,8 @@ public class DeleteContactCommandTest {
         indexes.add(INDEX_FIRST_PERSON);
         DeleteContactCommand deleteContactCommand = new DeleteContactCommand(indexes);
 
-        String expectedMessage = String.format(DeleteContactCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        String expectedMessage = String.format(DeleteContactCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                "\n\n" + personToDelete);
 
         ModelManager expectedModel = new ModelManagerBuilder().withAddressBook(model.getAddressBook()).build();
         expectedModel.deletePerson(personToDelete);
@@ -64,7 +65,8 @@ public class DeleteContactCommandTest {
         indexes.add(INDEX_FIRST_PERSON);
         DeleteContactCommand deleteContactCommand = new DeleteContactCommand(indexes);
 
-        String expectedMessage = String.format(DeleteContactCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        String expectedMessage = String.format(DeleteContactCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                "\n\n" + personToDelete);
 
         Model expectedModel = new ModelManagerBuilder().withAddressBook(model.getAddressBook()).build();
         expectedModel.deletePerson(personToDelete);

--- a/src/test/java/seedu/address/logic/commands/contacts/DeleteContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contacts/DeleteContactCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.ArrayList;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;

--- a/src/test/java/seedu/address/logic/commands/contacts/DeleteContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contacts/DeleteContactCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
@@ -29,7 +30,10 @@ public class DeleteContactCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getSortedFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteContactCommand deleteContactCommand = new DeleteContactCommand(INDEX_FIRST_PERSON);
+
+        ArrayList<Index> indexes = new ArrayList<>();
+        indexes.add(INDEX_FIRST_PERSON);
+        DeleteContactCommand deleteContactCommand = new DeleteContactCommand(indexes);
 
         String expectedMessage = String.format(DeleteContactCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -42,7 +46,10 @@ public class DeleteContactCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getSortedFilteredPersonList().size() + 1);
-        DeleteContactCommand deleteContactCommand = new DeleteContactCommand(outOfBoundIndex);
+
+        ArrayList<Index> indexes = new ArrayList<>();
+        indexes.add(outOfBoundIndex);
+        DeleteContactCommand deleteContactCommand = new DeleteContactCommand(indexes);
 
         assertCommandFailure(deleteContactCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -52,7 +59,10 @@ public class DeleteContactCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getSortedFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteContactCommand deleteContactCommand = new DeleteContactCommand(INDEX_FIRST_PERSON);
+
+        ArrayList<Index> indexes = new ArrayList<>();
+        indexes.add(INDEX_FIRST_PERSON);
+        DeleteContactCommand deleteContactCommand = new DeleteContactCommand(indexes);
 
         String expectedMessage = String.format(DeleteContactCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -71,21 +81,27 @@ public class DeleteContactCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteContactCommand deleteContactCommand = new DeleteContactCommand(outOfBoundIndex);
+        ArrayList<Index> indexes = new ArrayList<>();
+        indexes.add(outOfBoundIndex);
+        DeleteContactCommand deleteContactCommand = new DeleteContactCommand(indexes);
 
         assertCommandFailure(deleteContactCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeleteContactCommand deleteFirstCommand = new DeleteContactCommand(INDEX_FIRST_PERSON);
-        DeleteContactCommand deleteSecondCommand = new DeleteContactCommand(INDEX_SECOND_PERSON);
+        ArrayList<Index> indexes1 = new ArrayList<>();
+        indexes1.add(INDEX_FIRST_PERSON);
+        DeleteContactCommand deleteFirstCommand = new DeleteContactCommand(indexes1);
+        ArrayList<Index> indexes2 = new ArrayList<>();
+        indexes2.add(INDEX_SECOND_PERSON);
+        DeleteContactCommand deleteSecondCommand = new DeleteContactCommand(indexes2);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteContactCommand deleteFirstCommandCopy = new DeleteContactCommand(INDEX_FIRST_PERSON);
+        DeleteContactCommand deleteFirstCommandCopy = new DeleteContactCommand(indexes1);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -145,7 +145,10 @@ public class AddressBookParserTest {
         DeleteEventCommand command = (DeleteEventCommand) parser.parseCommand(
                 DeleteEventCommand.COMMAND_WORD + " " + DeleteEventCommand.COMMAND_TYPE + " "
                         + INDEX_FIRST_EVENT.getOneBased());
-        assertEquals(new DeleteEventCommand(INDEX_FIRST_EVENT), command);
+
+        ArrayList<Index> indexes = new ArrayList<>();
+        indexes.add(INDEX_FIRST_EVENT);
+        assertEquals(new DeleteEventCommand(indexes), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -11,12 +11,14 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.contacts.AddContactCommand;
 import seedu.address.logic.commands.contacts.ClearContactCommand;
 import seedu.address.logic.commands.contacts.DeleteContactCommand;
@@ -71,7 +73,9 @@ public class AddressBookParserTest {
         DeleteContactCommand command = (DeleteContactCommand) parser.parseCommand(
                 DeleteContactCommand.COMMAND_WORD + " " + DeleteContactCommand.COMMAND_TYPE + " "
                         + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteContactCommand(INDEX_FIRST_PERSON), command);
+        ArrayList<Index> indexes = new ArrayList<>();
+        indexes.add(INDEX_FIRST_PERSON);
+        assertEquals(new DeleteContactCommand(indexes), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/contacts/DeleteContactCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contacts/DeleteContactCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.ArrayList;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;

--- a/src/test/java/seedu/address/logic/parser/contacts/DeleteContactCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contacts/DeleteContactCommandParserTest.java
@@ -5,8 +5,10 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.contacts.DeleteContactCommand;
 
 /**
@@ -22,7 +24,9 @@ public class DeleteContactCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteContactCommand(INDEX_FIRST_PERSON));
+        ArrayList<Index> indexes = new ArrayList<>();
+        indexes.add(INDEX_FIRST_PERSON);
+        assertParseSuccess(parser, "1", new DeleteContactCommand(indexes));
     }
 
     @Test


### PR DESCRIPTION
Single positive integers are still possible
Example use now (applies to both events and contacts):
Command
![image](https://user-images.githubusercontent.com/69659433/97857196-55376580-1d38-11eb-8dc3-0d496e10f9dc.png)
Result
![image](https://user-images.githubusercontent.com/69659433/97857319-7ef08c80-1d38-11eb-996a-ea96efbab9c3.png)
