### PR TITLE
Update day difference to be difference by dates, rather than absolute time

### DIFF
--- a/src/main/java/seedu/address/model/event/Time.java
+++ b/src/main/java/seedu/address/model/event/Time.java
@@ -78,7 +78,7 @@ public class Time {
                 .append(time.format(DateTimeFormatter.ofPattern("K:mma")).toLowerCase());
 
         LocalDate now = LocalDate.now();
-        long dayDifference = DAYS.between(now, time);
+        long dayDifference = DAYS.between(now, time.toLocalDate());
         if (dayDifference < 0) {
             if (dayDifference < -1) {
                 builder.append(" (" + (dayDifference * -1) + " days ago)");

--- a/src/main/java/seedu/address/model/event/Time.java
+++ b/src/main/java/seedu/address/model/event/Time.java
@@ -74,7 +74,8 @@ public class Time {
         builder.append(time.getDayOfWeek().getDisplayName(TextStyle.SHORT_STANDALONE, Locale.ENGLISH) + " ")
                 .append(getDayOfMonthAsString() + " ")
                 .append(time.getMonth().getDisplayName(TextStyle.SHORT_STANDALONE, Locale.ENGLISH) + " ")
-                .append(time.getYear());
+                .append(time.getYear() + " ")
+                .append(time.format(DateTimeFormatter.ofPattern("K:mma")).toLowerCase());
 
         LocalDate now = LocalDate.now();
         long dayDifference = DAYS.between(now, time);

--- a/src/main/java/seedu/address/model/event/Time.java
+++ b/src/main/java/seedu/address/model/event/Time.java
@@ -4,6 +4,7 @@ import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -75,7 +76,7 @@ public class Time {
                 .append(time.getMonth().getDisplayName(TextStyle.SHORT_STANDALONE, Locale.ENGLISH) + " ")
                 .append(time.getYear());
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDate now = LocalDate.now();
         long dayDifference = DAYS.between(now, time);
         if (dayDifference < 0) {
             if (dayDifference < -1) {


### PR DESCRIPTION
Only a full 24hrs was counted as a day before. So when the event is in say 12 hrs the day after, it would display as "(Today)". 

This has been fixed and now displays "(In 1 day)".

This also means that they number of days to event is consistent through out the day, only changing at midnight rather than changing at the time of event.

Closes #233 