### PR TITLE
Update delete -c and edit -c to delete/edit associated FauxPersons

### DIFF
--- a/src/main/java/seedu/address/model/Calendar.java
+++ b/src/main/java/seedu/address/model/Calendar.java
@@ -7,6 +7,8 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.UniqueEventList;
+import seedu.address.model.event.association.FauxPerson;
+import seedu.address.model.person.Person;
 
 /**
  * Wraps all data at the calendar level
@@ -92,6 +94,24 @@ public class Calendar implements ReadOnlyCalendar {
     public void removeEvent(Event key) {
         events.remove(key);
     }
+
+
+    // associated persons methods
+
+    /**
+     * Removes {@code Person} from being associated with any event in this {@code Calendar}.
+     */
+    public void deletePersonAssociation(Person person) {
+        events.deleteFauxPerson(new FauxPerson(person));
+    }
+
+    /**
+     * Sets associated {@code target} to {@code editedPerson} in {@code Calendar}.
+     */
+    public void setPersonAssociation(Person target, Person editedPerson) {
+        events.setFauxPerson(new FauxPerson(target), new FauxPerson(editedPerson));
+    }
+
 
     //// util methods
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -213,6 +213,7 @@ public class ModelManager implements Model {
     @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
+        calendar.deletePersonAssociation(target);
     }
 
     @Override
@@ -285,6 +286,7 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+        calendar.setPersonAssociation(target, editedPerson);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -31,6 +31,16 @@ public class Event {
         this.associatedPersons.addAll(associatedPersons);
     }
 
+    /**
+     * Makes a copy of {@Code toBeCopied}
+     */
+    public Event(Event toBeCopied) {
+        requireAllNonNull(toBeCopied);
+        this.description = toBeCopied.description;
+        this.time = toBeCopied.time;
+        this.associatedPersons.addAll(toBeCopied.associatedPersons);
+    }
+
     public Description getDescription() {
         return description;
     }
@@ -58,6 +68,22 @@ public class Event {
         return otherEvent != null
                 && otherEvent.getDescription().equals(getDescription())
                 && otherEvent.getTime().equals(getTime());
+    }
+
+    /**
+     * Deletes instances of {@code fauxPerson} associated to this event.
+     */
+    public void deleteFauxPerson(FauxPerson toBeDeleted) {
+        associatedPersons.remove(toBeDeleted);
+    }
+
+    /**
+     * Sets associated {@code target} to {@code editedFauxPerson} in this event.
+     */
+    public void setFauxPerson(FauxPerson target, FauxPerson editedFauxPerson) {
+        if (associatedPersons.remove(target)) {
+            associatedPersons.add(editedFauxPerson);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.event.association.FauxPerson;
 import seedu.address.model.event.exceptions.DuplicateEventException;
 import seedu.address.model.event.exceptions.EventNotFoundException;
 
@@ -95,6 +96,38 @@ public class UniqueEventList implements Iterable<Event> {
         }
 
         internalList.setAll(events);
+    }
+
+    /**
+     * Deletes instances of {@code fauxPerson} from events in this list.
+     */
+    public void deleteFauxPerson(FauxPerson fauxPerson) {
+        for (Event event : internalList) {
+            int index = internalList.indexOf(event);
+            // this is in a for loop, the following should not happen
+            if (index == -1) {
+                throw new EventNotFoundException();
+            }
+            Event editedEvent = new Event(event);
+            editedEvent.deleteFauxPerson(fauxPerson);
+            internalList.set(index, editedEvent);
+        }
+    }
+
+    /**
+     * Sets associated {@code target} to {@code editedPerson} for events in this list.
+     */
+    public void setFauxPerson(FauxPerson target, FauxPerson editedFauxPerson) {
+        for (Event event : internalList) {
+            int index = internalList.indexOf(event);
+            // this is in a for loop, the following should not happen
+            if (index == -1) {
+                throw new EventNotFoundException();
+            }
+            Event editedEvent = new Event(event);
+            editedEvent.setFauxPerson(target, editedFauxPerson);
+            internalList.set(index, editedEvent);
+        }
     }
 
     /**


### PR DESCRIPTION
Any command that uses deletePerson(Person target) under ModelManager class, which currently is delete -c only, will remove the person from associated with any event. Achieving a full delete effect. Closes #206 
Command
![image](https://user-images.githubusercontent.com/69659433/97863745-700ed780-1d42-11eb-90d1-ca622d11704c.png)
Result
![image](https://user-images.githubusercontent.com/69659433/97863764-7a30d600-1d42-11eb-9668-5c7ec307ef54.png)


Editing a person now affects the displayed names of associated persons.
Command
![image](https://user-images.githubusercontent.com/69659433/97863357-cdeeef80-1d41-11eb-82ed-19bae5ba3a7b.png)
Result
![image](https://user-images.githubusercontent.com/69659433/97863367-d1827680-1d41-11eb-93b0-10abd46d7920.png)
