### PR TITLE
Set limit for number of displayed associated persons per event

### DIFF
--- a/src/main/java/seedu/address/logic/commands/events/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/events/EditEventCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_PERSON;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_EVENTS;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -109,8 +110,9 @@ public class EditEventCommand extends Command {
         Description updatedDescription = editEventDescriptor.getDescription().orElse(eventToEdit.getDescription());
         Time updatedTime = editEventDescriptor.getTime().orElse(eventToEdit.getTime());
 
-        // updatedAssociatedPersons' part
+        // updatedAssociatedPersons' part, sorting is necessary to sync with the order of displayed names in the GUI
         ArrayList<FauxPerson> tempAssociatedPersons = new ArrayList<>(eventToEdit.getAssociatedPersons());
+        tempAssociatedPersons.sort(Comparator.comparing(current -> current.displayName));
 
         tempAssociatedPersons = removeFauxPersons(tempAssociatedPersons, editEventDescriptor);
         tempAssociatedPersons = addFauxPersons(tempAssociatedPersons, editEventDescriptor, lastShownPersonList);

--- a/src/main/java/seedu/address/logic/commands/events/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/events/EditEventCommand.java
@@ -111,6 +111,7 @@ public class EditEventCommand extends Command {
         Time updatedTime = editEventDescriptor.getTime().orElse(eventToEdit.getTime());
 
         // updatedAssociatedPersons' part, sorting is necessary to sync with the order of displayed names in the GUI
+        // Sorting for display in the GUI component can be found in EventCard class
         ArrayList<FauxPerson> tempAssociatedPersons = new ArrayList<>(eventToEdit.getAssociatedPersons());
         tempAssociatedPersons.sort(Comparator.comparing(current -> current.displayName));
 

--- a/src/main/java/seedu/address/ui/EventCard.java
+++ b/src/main/java/seedu/address/ui/EventCard.java
@@ -20,7 +20,7 @@ public class EventCard extends UiPart<Region> {
 
     private static final String MESSAGE_PERSON_LIMIT_REACHED = "...";
 
-    private static final int associatedPersonsLimit = 5;
+    private static final int associatedPersonsLimit = 6;
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.

--- a/src/main/java/seedu/address/ui/EventCard.java
+++ b/src/main/java/seedu/address/ui/EventCard.java
@@ -20,6 +20,7 @@ public class EventCard extends UiPart<Region> {
 
     private static final String MESSAGE_PERSON_LIMIT_REACHED = "... %d more attendee(s)";
 
+    // TODO: perhaps shift this out to UserPrefs so it can be modified from there instead
     private static final int associatedPersonsLimit = 6;
 
     /**

--- a/src/main/java/seedu/address/ui/EventCard.java
+++ b/src/main/java/seedu/address/ui/EventCard.java
@@ -1,11 +1,15 @@
 package seedu.address.ui;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.event.Event;
+import seedu.address.model.event.association.FauxPerson;
 
 /**
  * An UI component that displays information of a {@code Event}.
@@ -13,6 +17,10 @@ import seedu.address.model.event.Event;
 public class EventCard extends UiPart<Region> {
 
     private static final String FXML = "EventListCard.fxml";
+
+    private static final String MESSAGE_PERSON_LIMIT_REACHED = "...";
+
+    private static final int associatedPersonsLimit = 3;
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -48,9 +56,29 @@ public class EventCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         description.setText(event.getDescription().fullDescription);
         time.setText(event.getTime().toDisplayString());
-        // no sorting here, as to show it in order of user input
-        event.getAssociatedPersons().stream()
-                .forEach(fauxPerson -> tags.getChildren().add(new Label(fauxPerson.displayName)));
+        setAssociatedPersons(event);
+    }
+
+    /**
+     * Sets the associated persons in this card to be from a event.
+     * Associated persons are sorted by alphabetic order.
+     * @param event Associated persons is taken from this event.
+     */
+    private void setAssociatedPersons(Event event) {
+        ArrayList<FauxPerson> associatedPersons = new ArrayList<>();
+        associatedPersons.addAll(event.getAssociatedPersons());
+        associatedPersons.sort(Comparator.comparing(current -> current.displayName));
+
+        int numOfDisplayedNames = 0;
+        for (FauxPerson fauxPerson : associatedPersons) {
+            if (numOfDisplayedNames <= associatedPersonsLimit) {
+                tags.getChildren().add(new Label(fauxPerson.displayName));
+                numOfDisplayedNames++;
+            } else {
+                tags.getChildren().add(new Label(MESSAGE_PERSON_LIMIT_REACHED));
+                break;
+            }
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/EventCard.java
+++ b/src/main/java/seedu/address/ui/EventCard.java
@@ -20,7 +20,7 @@ public class EventCard extends UiPart<Region> {
 
     private static final String MESSAGE_PERSON_LIMIT_REACHED = "...";
 
-    private static final int associatedPersonsLimit = 3;
+    private static final int associatedPersonsLimit = 5;
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -71,7 +71,7 @@ public class EventCard extends UiPart<Region> {
 
         int numOfDisplayedNames = 0;
         for (FauxPerson fauxPerson : associatedPersons) {
-            if (numOfDisplayedNames <= associatedPersonsLimit) {
+            if (numOfDisplayedNames < associatedPersonsLimit) {
                 tags.getChildren().add(new Label(fauxPerson.displayName));
                 numOfDisplayedNames++;
             } else {

--- a/src/main/java/seedu/address/ui/EventCard.java
+++ b/src/main/java/seedu/address/ui/EventCard.java
@@ -55,6 +55,7 @@ public class EventCard extends UiPart<Region> {
         this.event = event;
         id.setText(displayedIndex + ". ");
         description.setText(event.getDescription().fullDescription);
+        time.setText(event.getTime().getDisplayName());
         setAssociatedPersons(event);
     }
 

--- a/src/main/java/seedu/address/ui/EventCard.java
+++ b/src/main/java/seedu/address/ui/EventCard.java
@@ -18,7 +18,7 @@ public class EventCard extends UiPart<Region> {
 
     private static final String FXML = "EventListCard.fxml";
 
-    private static final String MESSAGE_PERSON_LIMIT_REACHED = "...";
+    private static final String MESSAGE_PERSON_LIMIT_REACHED = "... %d more attendee(s)";
 
     private static final int associatedPersonsLimit = 6;
 
@@ -67,6 +67,9 @@ public class EventCard extends UiPart<Region> {
     private void setAssociatedPersons(Event event) {
         ArrayList<FauxPerson> associatedPersons = new ArrayList<>();
         associatedPersons.addAll(event.getAssociatedPersons());
+        /* Sorted by alphabetical order.
+         * This needs to sync with the sorting of associated persons before modification in EditEvent class.
+         */
         associatedPersons.sort(Comparator.comparing(current -> current.displayName));
 
         int numOfDisplayedNames = 0;
@@ -75,7 +78,9 @@ public class EventCard extends UiPart<Region> {
                 tags.getChildren().add(new Label(fauxPerson.displayName));
                 numOfDisplayedNames++;
             } else {
-                tags.getChildren().add(new Label(MESSAGE_PERSON_LIMIT_REACHED));
+                assert numOfDisplayedNames >= associatedPersonsLimit;
+                tags.getChildren().add(new Label(String.format(MESSAGE_PERSON_LIMIT_REACHED,
+                        associatedPersons.size() - associatedPersonsLimit)));
                 break;
             }
         }


### PR DESCRIPTION
Each event is limited to showing 6 associated persons.
Example:
![image](https://user-images.githubusercontent.com/69659433/97969125-8d06e180-1dfa-11eb-9e84-3120edf74f8f.png)
Closes #106 