### PR TITLE
Fix delete person tag bug

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -381,6 +381,8 @@ Tags present a new way for you to classify and group your contacts together. Man
 allow you to perform tag-level actions (to be implemented) such as adding all contacts under a tag into an event. 
 Below are some commands to facilitate tag management.
 
+**Note: Tags can exist without being displayed within the contact window.** I.e. A super-tag with no contacts directly associated with it.
+
 **Note: For a tag to exist, it has to have at least one contact tagged OR contains at least one child-tag.**
 Tags that do not meet this criterion will be deleted. 
 

--- a/src/main/java/seedu/address/model/ContactTagIntegrationManager.java
+++ b/src/main/java/seedu/address/model/ContactTagIntegrationManager.java
@@ -7,7 +7,6 @@ import java.util.function.Consumer;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.TagTree;
-import seedu.address.model.tag.TagTreeImpl;
 
 /**
  * Class that controls {@code Tag} relationships and interactions between {@code Tag}s and {@Code Person}s.

--- a/src/main/java/seedu/address/model/ContactTagIntegrationManager.java
+++ b/src/main/java/seedu/address/model/ContactTagIntegrationManager.java
@@ -170,6 +170,10 @@ public class ContactTagIntegrationManager {
         }
     }
 
+    /**
+     * Removes the {@code tag} from a {@code person}.
+     * If the {@code tag} no longer exists, the {@code tag} is deleted.
+     */
     public void removePersonFromTag(Tag tag, Person person) {
         addressBook.removePersonFromTag(tag, person);
         if (!hasTag(tag)) {

--- a/src/main/java/seedu/address/model/ContactTagIntegrationManager.java
+++ b/src/main/java/seedu/address/model/ContactTagIntegrationManager.java
@@ -18,14 +18,6 @@ public class ContactTagIntegrationManager {
     private TagTree tagTree;
 
     /**
-     * Creates a {@code ContactTagIntegrationManager} from the given {@code addressBook} and a new {@code tagTree}.
-     */
-    public ContactTagIntegrationManager(AddressBook addressBook) {
-        this.addressBook = addressBook;
-        tagTree = new TagTreeImpl();
-    }
-
-    /**
      * Creates a ContactTagIntegrationManager from the given {@code addressBook} and {@code tagTree}.
      */
     public ContactTagIntegrationManager(AddressBook addressBook, TagTree tagTree) {
@@ -175,6 +167,13 @@ public class ContactTagIntegrationManager {
             if (!hasTag(tag)) {
                 deleteTag(tag);
             }
+        }
+    }
+
+    public void removePersonFromTag(Tag tag, Person person) {
+        addressBook.removePersonFromTag(tag, person);
+        if (!hasTag(tag)) {
+            deleteTag(tag);
         }
     }
 

--- a/src/main/java/seedu/address/model/ContactTagIntegrationManager.java
+++ b/src/main/java/seedu/address/model/ContactTagIntegrationManager.java
@@ -154,8 +154,8 @@ public class ContactTagIntegrationManager {
     }
 
     /**
-     * Changes the {@code person} in the addressbook with {@code editedPerson}.
-     * If there {@code person} was the only contact in a tag and {@code editedPerson} has them removed,
+     * Changes {@code person} in the addressbook to {@code editedPerson}.
+     * If {@code person} is the only contact in a tag and {@code editedPerson} has them removed,
      * the tag is deleted as well.
      */
     public void setPerson(Person person, Person editedPerson) {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -218,7 +218,7 @@ public class ModelManager implements Model {
 
     @Override
     public void deletePerson(Person target) {
-        addressBook.removePerson(target);
+        contactTagIntegrationManager.deletePerson(target);
         calendar.deletePersonAssociation(target);
     }
 
@@ -291,7 +291,7 @@ public class ModelManager implements Model {
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
 
-        addressBook.setPerson(target, editedPerson);
+        contactTagIntegrationManager.setPerson(target, editedPerson);
         calendar.setPersonAssociation(target, editedPerson);
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -284,7 +284,7 @@ public class ModelManager implements Model {
 
     @Override
     public void removePersonFromTag(Tag tag, Person person) {
-        addressBook.removePersonFromTag(tag, person);
+        contactTagIntegrationManager.removePersonFromTag(tag, person);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/TagTree.java
+++ b/src/main/java/seedu/address/model/tag/TagTree.java
@@ -28,6 +28,11 @@ public abstract class TagTree implements ReadOnlyTagTree {
     public abstract Set<Tag> getSubTagsOf(Tag tag);
 
     /**
+     * Returns all super-tags of {@code tag}.
+     */
+    public abstract Set<Tag> getSuperTagsOf(Tag tag);
+
+    /**
      * Returns all sub-tags below {@code tag} in the tag-hierarchy.
      * I.e. All sub-tags of {@code tag}, all sub-tags of those sub-tags, etc.
      */

--- a/src/main/java/seedu/address/model/tag/TagTreeImpl.java
+++ b/src/main/java/seedu/address/model/tag/TagTreeImpl.java
@@ -84,6 +84,11 @@ public class TagTreeImpl extends TagTree {
     }
 
     @Override
+    public Set<Tag> getSuperTagsOf(Tag tag) {
+        return tagSuperTagMap.containsKey(tag) ? Set.copyOf(tagSuperTagMap.get(tag)) : Set.of();
+    }
+
+    @Override
     public Set<Tag> getSubTagsRecursive(Tag tag) {
         Set<Tag> finalSet = new HashSet<>();
         Consumer<Tag> consumer = new Consumer<Tag>() {

--- a/src/test/java/seedu/address/model/tag/TagTreeImplTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTreeImplTest.java
@@ -113,7 +113,7 @@ public class TagTreeImplTest {
     }
 
     @Test
-    public void deleteTag_tagInTree_noChange() {
+    public void deleteTag_tagNotInTree_noChange() {
         TagTreeImpl testTree = buildTestTree();
         testTree.deleteTag(TAG_CS2040S_NOT_TREE);
         assertEquals(testTree, buildTestTree());


### PR DESCRIPTION
Fixed indirect tag deletions to properly get rid of hanging tags (tags that should not exist but are still appear to be) involved in 
- editContactCommand (contact has tag removed, tag has goes from 1 contact to 0 contacts. With no child-tags, tag should be deleted too)
- deleteContactCommand (contact deleted might be the only contact in a tag with no child tags. Tag should therefore be deleted)
- editTagCommand (a parent-tag with no direct contacts and only one sub-tag has its only sub-tag removed. Tag should be deleted)
- any of the above causing a parent tag to have its only child tag deleted. If this parent tag has no direct contacts, it should be deleted too (same goes for any of its parent tags, etc.)

Update test cases for new methods implemented in `ContactTagIntegrationManager` that replaces the `AddressBook` methods in `ModelManager`.

Added a portion in UG to specify that tags can exist (and thus cannot be added) even if there are no contacts currently displayed that have them..