### PR TITLE
Fix Time displayed error

### DIFF
--- a/src/main/java/seedu/address/model/event/Time.java
+++ b/src/main/java/seedu/address/model/event/Time.java
@@ -80,7 +80,7 @@ public class Time {
                 .append(getDayOfMonthAsString() + " ")
                 .append(time.getMonth().getDisplayName(TextStyle.SHORT_STANDALONE, Locale.ENGLISH) + " ")
                 .append(time.getYear() + " ")
-                .append(time.format(DateTimeFormatter.ofPattern("K:mma")).toLowerCase());
+                .append(time.format(DateTimeFormatter.ofPattern("h:mma")).toLowerCase());
 
         LocalDate now = LocalDate.now();
         long dayDifference = DAYS.between(now, time.toLocalDate());


### PR DESCRIPTION
12am and 12pm are now displayed properly instead of 0am and 0pm. Closes #269.
![image](https://user-images.githubusercontent.com/69659433/98498145-01b9a000-2281-11eb-93e9-cf47568417bb.png)
